### PR TITLE
[feat] 이메일 등록 API 구현 #5 Open

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,12 +35,16 @@ jobs:
         env:
           APPLICATION_PROPERTIES: ${{ secrets.APPLICATION_PROPERTIES }}
           ERROR_MESSAGES_PROPERTIES: ${{ secrets.ERROR_MESSAGES_PROPERTIES }}
+          TEST_APPLICATION_PROPERTIES: ${{ secrets.TEST_APPLICATION_PROPERTIES }}
+
         run: |
           cd ./src
           rm -rf main/resources/application.yml
           mkdir -p main/resources
+          mkdir -p test/resources
           echo "$APPLICATION_PROPERTIES" > main/resources/application.yml
           echo "$ERROR_MESSAGES_PROPERTIES" > main/resources/api-error-messages.properties
+          echo "$TEST_APPLICATION_PROPERTIES" > test/resources/application.yml
 
       - name: gradlew 권한 부여
         run: chmod +x gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ out/
 ### yml ###
 src/main/resources/application.yml
 src/main/resources/application-local.yml
+src/test/resources/application.yml
 
 ###properties###
 src/main/resources/api-error-messages.properties
+src/test/resources/api-error-messages.properties

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,11 @@ dependencies {
 
     // thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    // JUnit
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.0'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,15 @@ dependencies {
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    //mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/capstone/backend/core/configuration/AsyncConfig.java
+++ b/src/main/java/com/capstone/backend/core/configuration/AsyncConfig.java
@@ -1,5 +1,6 @@
 package com.capstone.backend.core.configuration;
 
+import java.util.concurrent.ThreadPoolExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -15,6 +16,7 @@ public class AsyncConfig {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(20);
         executor.setThreadNamePrefix("Mail-Executor-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/capstone/backend/core/configuration/AsyncConfig.java
+++ b/src/main/java/com/capstone/backend/core/configuration/AsyncConfig.java
@@ -1,0 +1,21 @@
+package com.capstone.backend.core.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "mailTaskExecutor")
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("Mail-Executor-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/capstone/backend/core/configuration/RedisConfig.java
+++ b/src/main/java/com/capstone/backend/core/configuration/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.capstone.backend.core.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+
+        // 직렬화 설정 (Key: String, Value: JSON)
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        // Optional: 해시 키/값 직렬화도 설정
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/capstone/backend/core/configuration/SecurityConfig.java
+++ b/src/main/java/com/capstone/backend/core/configuration/SecurityConfig.java
@@ -24,7 +24,8 @@ public class SecurityConfig {
             "/",
             "/swagger-ui/**",
             "/v3/api-docs/**",
-            "/v1/member/auth-mail"
+            "/v1/member/auth-mail",
+            "/v1/member/auth-code"
     };
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/capstone/backend/core/configuration/SecurityConfig.java
+++ b/src/main/java/com/capstone/backend/core/configuration/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
             "/",
             "/swagger-ui/**",
             "/v3/api-docs/**",
+            "/v1/member/auth-mail"
     };
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/capstone/backend/core/infrastructure/exception/CustomException.java
+++ b/src/main/java/com/capstone/backend/core/infrastructure/exception/CustomException.java
@@ -3,25 +3,29 @@ package com.capstone.backend.core.infrastructure.exception;
 import com.capstone.backend.core.common.web.response.ExtendedHttpStatus;
 import com.capstone.backend.core.common.web.response.exception.ErrorCodeResolvingApiErrorException;
 
-public class BadRequestException extends ErrorCodeResolvingApiErrorException {
+public class CustomException extends ErrorCodeResolvingApiErrorException {
 
     // 기본 code만 전달하는 생성자
-    public BadRequestException() {
+    public CustomException() {
         super(ExtendedHttpStatus.BAD_REQUEST, "bad-request");
     }
 
     // code를 명시적으로 전달하는 생성자
-    public BadRequestException(String code) {
+    public CustomException(String code) {
         super(ExtendedHttpStatus.BAD_REQUEST, code);
     }
 
+    public CustomException(ExtendedHttpStatus extendedHttpStatus, String code) {
+        super(extendedHttpStatus, code);
+    }
+
     // code + cause 둘 다 전달하는 생성자
-    public BadRequestException(String code, Throwable cause) {
+    public CustomException(String code, Throwable cause) {
         super(ExtendedHttpStatus.BAD_REQUEST, code, cause);
     }
 
     // cause만 전달하는 경우 (code는 기본값 사용)
-    public BadRequestException(Throwable cause) {
+    public CustomException(Throwable cause) {
         super(ExtendedHttpStatus.BAD_REQUEST, "bad-request", cause);
     }
 }

--- a/src/main/java/com/capstone/backend/core/infrastructure/mail/MailService.java
+++ b/src/main/java/com/capstone/backend/core/infrastructure/mail/MailService.java
@@ -107,6 +107,11 @@ public class MailService {
     public Boolean verifyCode(String email, String authCode) {
         memberService.isAlreadyPresentMemberEmail(email);
 
+        if(!redisTemplate.hasKey(AUTH_CODE_PREFIX + email)){
+            log.warn("이메일 인증 실패: email={}, 입력 코드={}", email, authCode);
+            return false;
+        }
+
         String redisAuthCode = redisTemplate.opsForValue().get(AUTH_CODE_PREFIX + email).toString();
 
         if (redisAuthCode == null || !redisAuthCode.equals(authCode)) {

--- a/src/main/java/com/capstone/backend/core/infrastructure/mail/MailService.java
+++ b/src/main/java/com/capstone/backend/core/infrastructure/mail/MailService.java
@@ -1,0 +1,127 @@
+package com.capstone.backend.core.infrastructure.mail;
+
+import com.capstone.backend.core.common.web.response.ExtendedHttpStatus;
+import com.capstone.backend.core.infrastructure.exception.CustomException;
+import com.capstone.backend.member.domain.service.MemberService;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MailService {
+    private static final String AUTH_CODE_PREFIX = "AuthCode:";
+    private static final String AUTH_REQUEST_PREFIX = "AuthRequest:";
+
+    private final JavaMailSender mailSender;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final MemberService memberService;
+    private final TemplateEngine templateEngine;
+
+    @Value("${spring.mail.mail_auth_code_expiration}")
+    private long authCodeExpirationMillis;
+
+    @Value("${spring.mail.username}")
+    private String mailSenderAddress;
+
+    @Async("mailTaskExecutor")
+    public void sendVerificationCode(String email) {
+        memberService.isAlreadyPresentMemberEmail(email);
+
+        String title = "졸업 프로젝트 이메일 인증 번호";
+        String authCode = generateAuthCode();
+
+        // 5분 내에 인증 코드 요청이 있었는지 확인
+        if (redisTemplate.hasKey(AUTH_REQUEST_PREFIX + email)) {
+            log.error("이메일 전송 실패: email={}, error={}", email, "5분 뒤에 다시 시도해주세요");
+            throw new CustomException("capstone.mail.too.many.request");
+        }
+
+        try {
+            sendMail(email, title, authCode);
+
+            // Redis에 인증 코드 저장 (key: AuthCode + email, value: authCode)
+            redisTemplate.opsForValue().set(
+                    AUTH_CODE_PREFIX + email,
+                    authCode,
+                    Duration.ofMillis(authCodeExpirationMillis)
+            );
+            redisTemplate.opsForValue().set(
+                    AUTH_REQUEST_PREFIX + email,
+                    "REQUESTED",
+                    Duration.ofMinutes(5)
+            );
+
+            log.info("이메일 인증 코드 전송 성공: {}", email);
+        } catch (Exception e) {
+            log.error("이메일 전송 실패: email={}, error={}", email, e.getMessage(), e);
+            // 이메일 전송 실패 시 Redis에 저장된 인증 코드 삭제
+            redisTemplate.delete(AUTH_CODE_PREFIX + email);
+            throw new CustomException(ExtendedHttpStatus.INTERNAL_SERVER_ERROR, "capstone.mail.send.fail");
+        }
+    }
+
+    /**
+     * 이메일 전송
+     */
+    private void sendMail(String toEmail, String title, String authCode) throws MessagingException {
+        MimeMessage emailForm = createEmailForm(toEmail, title, authCode);
+        mailSender.send(emailForm);
+    }
+
+    /**
+     * 이메일 템플릿 생성
+     */
+    private MimeMessage createEmailForm(String toEmail, String title, String authCode) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        // Thymeleaf 템플릿 처리
+        Context context = new Context();
+        context.setVariable("verificationCode", authCode);
+        String htmlContent = templateEngine.process("verification-email", context);
+
+        helper.setTo(toEmail);
+        helper.setSubject(title);
+        helper.setText(htmlContent, true);
+        helper.setFrom(mailSenderAddress);
+
+        log.info("발신자 이메일 주소: {}", mailSenderAddress);
+        return message;
+    }
+
+    // 이메일 인증 코드 검증
+    public Boolean verifyCode(String email, String authCode) {
+        memberService.isAlreadyPresentMemberEmail(email);
+
+        String redisAuthCode = redisTemplate.opsForValue().get(AUTH_CODE_PREFIX + email).toString();
+
+        if (redisAuthCode == null || !redisAuthCode.equals(authCode)) {
+            log.warn("이메일 인증 실패: email={}, 입력 코드={}, Redis 코드={}", email, authCode, redisAuthCode);
+            return false;
+        }
+
+        log.info("이메일 인증 성공: email={}", email);
+        return true;
+    }
+
+    // 랜덤 인증 코드 6자리 생성
+    private String generateAuthCode() {
+        return new SecureRandom().ints(6, 0, 10)
+                .mapToObj(String::valueOf)
+                .collect(Collectors.joining());
+    }
+}

--- a/src/main/java/com/capstone/backend/global/entity/BaseEntity.java
+++ b/src/main/java/com/capstone/backend/global/entity/BaseEntity.java
@@ -1,0 +1,35 @@
+package com.capstone.backend.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+    // Getter & Setter
+    @Getter
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Getter
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted = false;
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        isDeleted = deleted;
+    }
+}

--- a/src/main/java/com/capstone/backend/member/domain/entity/Member.java
+++ b/src/main/java/com/capstone/backend/member/domain/entity/Member.java
@@ -1,8 +1,12 @@
 package com.capstone.backend.member.domain.entity;
 
 import com.capstone.backend.global.entity.BaseEntity;
+import com.capstone.backend.member.domain.service.MemberService;
+import com.capstone.backend.member.domain.value.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,4 +35,14 @@ public class Member extends BaseEntity {
     @Column(name = "PASSWORD", length = 100)
     private String password;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ROLE")
+    private Role role;
+
+    public static Member createTemporaryMember(String email) {
+        return Member.builder()
+                .email(email)
+                .role(Role.TEMPORARY_MEMBER)
+                .build();
+    }
 }

--- a/src/main/java/com/capstone/backend/member/domain/entity/Member.java
+++ b/src/main/java/com/capstone/backend/member/domain/entity/Member.java
@@ -1,7 +1,6 @@
 package com.capstone.backend.member.domain.entity;
 
 import com.capstone.backend.global.entity.BaseEntity;
-import com.capstone.backend.member.domain.service.MemberService;
 import com.capstone.backend.member.domain.value.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/capstone/backend/member/domain/entity/Member.java
+++ b/src/main/java/com/capstone/backend/member/domain/entity/Member.java
@@ -1,0 +1,34 @@
+package com.capstone.backend.member.domain.entity;
+
+import com.capstone.backend.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "MEMBER")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "MEMBER_ID")
+    private Long id;
+
+    @Column(name = "EMAIL", length = 30)
+    private String email;
+
+    @Column(name = "PASSWORD", length = 100)
+    private String password;
+
+}

--- a/src/main/java/com/capstone/backend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/capstone/backend/member/domain/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.capstone.backend.member.domain.repository;
+
+import com.capstone.backend.member.domain.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/capstone/backend/member/domain/service/MemberService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/MemberService.java
@@ -1,0 +1,38 @@
+package com.capstone.backend.member.domain.service;
+
+import com.capstone.backend.core.infrastructure.exception.CustomException;
+import com.capstone.backend.member.domain.entity.Member;
+import com.capstone.backend.member.domain.repository.MemberRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public Member getById(Long id) {
+        return findById(id)
+                .orElseThrow(() ->
+                        new CustomException("capstone.member.not.found"));
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Member> findById(Long id) {
+        return memberRepository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Member> findByEmail(String email) {
+        return memberRepository.findByEmail(email);
+    }
+    @Transactional(readOnly = true)
+    public void isAlreadyPresentMemberEmail(String email) {
+        if(findByEmail(email).isPresent()) {
+            throw new CustomException("capstone.member.not.found");
+        }
+    }
+}

--- a/src/main/java/com/capstone/backend/member/domain/service/MemberService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/MemberService.java
@@ -35,4 +35,9 @@ public class MemberService {
             throw new CustomException("capstone.member.not.found");
         }
     }
+
+    @Transactional
+    public void save(Member member){
+        memberRepository.save(member);
+    }
 }

--- a/src/main/java/com/capstone/backend/member/domain/service/MemberService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/MemberService.java
@@ -32,7 +32,7 @@ public class MemberService {
     @Transactional(readOnly = true)
     public void isAlreadyPresentMemberEmail(String email) {
         if(findByEmail(email).isPresent()) {
-            throw new CustomException("capstone.member.not.found");
+            throw new CustomException("capstone.member.already.exists");
         }
     }
 

--- a/src/main/java/com/capstone/backend/member/domain/value/Role.java
+++ b/src/main/java/com/capstone/backend/member/domain/value/Role.java
@@ -1,0 +1,5 @@
+package com.capstone.backend.member.domain.value;
+
+public enum Role {
+    TEMPORARY_MEMBER, MEMBER
+}

--- a/src/main/java/com/capstone/backend/member/dto/request/SendAuthMailRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/SendAuthMailRequest.java
@@ -1,0 +1,9 @@
+package com.capstone.backend.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SendAuthMailRequest(
+   @Schema(description = "인증할 이메일", example = "abc@konkuk.ac.kr")
+   String email
+) {
+}

--- a/src/main/java/com/capstone/backend/member/dto/request/VerifyAuthCodeRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/VerifyAuthCodeRequest.java
@@ -1,0 +1,11 @@
+package com.capstone.backend.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record VerifyAuthCodeRequest (
+        @Schema(description = "확인할 이메일", example = "abc@konkuk.ac.kr")
+        String email,
+        @Schema(description = "인증코드", example = "123456")
+        String code
+){
+}

--- a/src/main/java/com/capstone/backend/member/facade/OnboardingFacade.java
+++ b/src/main/java/com/capstone/backend/member/facade/OnboardingFacade.java
@@ -1,0 +1,15 @@
+package com.capstone.backend.member.facade;
+
+import com.capstone.backend.core.infrastructure.mail.MailService;
+import com.capstone.backend.member.dto.request.SendAuthMailRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OnboardingFacade {
+    private final MailService mailService;
+    public void sendAuthMail(SendAuthMailRequest sendAuthMailRequest) {
+        mailService.sendVerificationCode(sendAuthMailRequest.email());
+    }
+}

--- a/src/main/java/com/capstone/backend/member/facade/OnboardingFacade.java
+++ b/src/main/java/com/capstone/backend/member/facade/OnboardingFacade.java
@@ -1,7 +1,10 @@
 package com.capstone.backend.member.facade;
 
 import com.capstone.backend.core.infrastructure.mail.MailService;
+import com.capstone.backend.member.domain.entity.Member;
+import com.capstone.backend.member.domain.service.MemberService;
 import com.capstone.backend.member.dto.request.SendAuthMailRequest;
+import com.capstone.backend.member.dto.request.VerifyAuthCodeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -9,7 +12,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OnboardingFacade {
     private final MailService mailService;
+    private final MemberService memberService;
     public void sendAuthMail(SendAuthMailRequest sendAuthMailRequest) {
         mailService.sendVerificationCode(sendAuthMailRequest.email());
+    }
+
+    public Boolean verifyAuthCode(VerifyAuthCodeRequest verifyAuthCodeRequest) {
+        if(!mailService.verifyCode(verifyAuthCodeRequest.email(), verifyAuthCodeRequest.code())){
+            return false;
+        }
+        memberService.save(Member.createTemporaryMember(verifyAuthCodeRequest.email()));
+        return true;
     }
 }

--- a/src/main/java/com/capstone/backend/member/presentation/ApiPath.java
+++ b/src/main/java/com/capstone/backend/member/presentation/ApiPath.java
@@ -1,0 +1,9 @@
+package com.capstone.backend.member.presentation;
+
+public final class ApiPath {
+    private ApiPath() {
+        // 인스턴스화 방지용 private 생성자
+    }
+
+    public static final String SEND_AUTH_MAIL = "/v1/member/auth-mail";
+}

--- a/src/main/java/com/capstone/backend/member/presentation/ApiPath.java
+++ b/src/main/java/com/capstone/backend/member/presentation/ApiPath.java
@@ -6,4 +6,5 @@ public final class ApiPath {
     }
 
     public static final String SEND_AUTH_MAIL = "/v1/member/auth-mail";
+    public static final String VERIFY_AUTH_CODE = "/v1/member/auth-code";
 }

--- a/src/main/java/com/capstone/backend/member/presentation/OnboardingController.java
+++ b/src/main/java/com/capstone/backend/member/presentation/OnboardingController.java
@@ -2,10 +2,13 @@ package com.capstone.backend.member.presentation;
 
 import com.capstone.backend.core.common.web.response.ApiResponse;
 import com.capstone.backend.member.dto.request.SendAuthMailRequest;
+import com.capstone.backend.member.dto.request.VerifyAuthCodeRequest;
 import com.capstone.backend.member.facade.OnboardingFacade;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -19,10 +22,20 @@ public class OnboardingController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(ApiPath.SEND_AUTH_MAIL)
+    @Operation(summary = "메일 인증 번호 보내기", description = "sendAuthMail")
     public ApiResponse<Boolean> sendAuthMail(
             @RequestBody SendAuthMailRequest sendAuthMailRequest
     ) {
         onboardingFacade.sendAuthMail(sendAuthMailRequest);
         return ApiResponse.success(true);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping(ApiPath.VERIFY_AUTH_CODE)
+    @Operation(summary = "메일 인증 번호 확인", description = "sendAuthMail")
+    public ApiResponse<Boolean> verifyAuthCode(
+            @RequestBody VerifyAuthCodeRequest verifyAuthCodeRequest
+    ) {
+        return ApiResponse.success(onboardingFacade.verifyAuthCode(verifyAuthCodeRequest));
     }
 }

--- a/src/main/java/com/capstone/backend/member/presentation/OnboardingController.java
+++ b/src/main/java/com/capstone/backend/member/presentation/OnboardingController.java
@@ -1,0 +1,28 @@
+package com.capstone.backend.member.presentation;
+
+import com.capstone.backend.core.common.web.response.ApiResponse;
+import com.capstone.backend.member.dto.request.SendAuthMailRequest;
+import com.capstone.backend.member.facade.OnboardingFacade;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "온보딩", description = "OnboardingController")
+public class OnboardingController {
+    private final OnboardingFacade onboardingFacade;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping(ApiPath.SEND_AUTH_MAIL)
+    public ApiResponse<Boolean> sendAuthMail(
+            @RequestBody SendAuthMailRequest sendAuthMailRequest
+    ) {
+        onboardingFacade.sendAuthMail(sendAuthMailRequest);
+        return ApiResponse.success(true);
+    }
+}

--- a/src/main/resources/templates/verification-email.html
+++ b/src/main/resources/templates/verification-email.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>이메일 인증</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; background-color: #f9f9f9; margin: 0; padding: 0;">
+<div style="max-width: 600px; margin: 50px auto; background: #ffffff; border-radius: 8px; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); overflow: hidden;">
+    <div style="background-color: #4CAF50; color: white; padding: 20px; text-align: center;">
+        <h1 style="margin: 0;">이메일 인증</h1>
+    </div>
+    <div style="padding: 30px; color: #333333;">
+        <p>안녕하세요!</p>
+        <p>아래 코드를 입력하여 이메일 인증을 완료하세요:</p>
+        <div style="display: inline-block; font-size: 24px; font-weight: bold; color: #4CAF50; background: #f1f1f1; padding: 10px 20px; border-radius: 4px; margin-top: 20px;" th:text="${verificationCode}">
+            ${verificationCode}
+        </div>
+    </div>
+    <div style="text-align: center; font-size: 12px; color: #888888; padding: 20px; border-top: 1px solid #dddddd;">
+        <p>이 메일은 건국대학교 졸업프로젝트2팀 시스템에 의해 자동 생성되었습니다.</p>
+        <p>문의사항이 있으시면 youngrok7878@gmail.com으로 연락주세요.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/capstone/backend/member/domain/service/MemberServiceTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/service/MemberServiceTest.java
@@ -1,0 +1,104 @@
+package com.capstone.backend.member.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.capstone.backend.member.domain.entity.Member;
+import com.capstone.backend.member.domain.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @DisplayName("getById - 성공")
+    @Test
+    void getById_success() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder()
+                        .id(memberId)
+                        .build();
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        // when
+        Member result = memberService.getById(memberId);
+
+        // then
+        assertThat(result.getId()).isEqualTo(memberId);
+        verify(memberRepository).findById(memberId);
+    }
+
+    @DisplayName("findById - 성공")
+    @Test
+    void findById_success() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder()
+                .id(memberId)
+                .build();
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        // when
+        Member result = memberService.getById(memberId);
+
+        //then
+        verify(memberRepository).findById(memberId);
+    }
+
+    @DisplayName("findByEmail - 성공")
+    @Test
+    void findByEmail_success() {
+        //given
+        Long memberId = 1L;
+        String email = "abc@def.com";
+        Member member = Member.builder()
+                .id(memberId)
+                .email(email)
+                .build();
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
+        // when
+        memberService.findByEmail(email);
+
+        //then
+        verify(memberRepository).findByEmail(email);
+    }
+
+    @DisplayName("isAlreadyPresentMemberEmail - 성공")
+    @Test
+    void isAlreadyPresentMemberEmail_success() {
+        //given
+        String email = "abc@def.com";
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.empty());
+        // when
+        memberService.isAlreadyPresentMemberEmail(email);
+        //then
+        verify(memberRepository).findByEmail(email);
+    }
+
+    @DisplayName("save - 성공")
+    @Test
+    void save_success(){
+        //given
+        Long memberId = 1L;
+        String email = "abc@def.com";
+        Member member = Member.builder()
+                .id(memberId)
+                .email(email)
+                .build();
+        //when
+        memberService.save(member);
+        //then
+        verify(memberRepository).save(member);
+    }
+}

--- a/src/test/java/com/capstone/backend/member/domain/service/MemberServiceTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/service/MemberServiceTest.java
@@ -50,7 +50,7 @@ class MemberServiceTest {
                 .build();
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         // when
-        Member result = memberService.getById(memberId);
+        memberService.findById(memberId);
 
         //then
         verify(memberRepository).findById(memberId);

--- a/src/test/java/com/capstone/backend/member/facade/OnboardingFacadeTest.java
+++ b/src/test/java/com/capstone/backend/member/facade/OnboardingFacadeTest.java
@@ -1,0 +1,57 @@
+package com.capstone.backend.member.facade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.capstone.backend.core.infrastructure.mail.MailService;
+import com.capstone.backend.member.domain.entity.Member;
+import com.capstone.backend.member.domain.service.MemberService;
+import com.capstone.backend.member.dto.request.SendAuthMailRequest;
+import com.capstone.backend.member.dto.request.VerifyAuthCodeRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OnboardingFacadeTest {
+    @Mock
+    private MailService mailService;
+
+    @Mock
+    private MemberService memberService;
+
+    @InjectMocks
+    private OnboardingFacade onboardingFacade;
+
+    @DisplayName("메일 인증 번호 보내기")
+    @Test
+    void sendAuthMail() {
+        //given
+        String email = "abc@def.com";
+        SendAuthMailRequest sendAuthMailRequest = new SendAuthMailRequest(email);
+        doNothing().when(mailService).sendVerificationCode(email);
+        //when
+        onboardingFacade.sendAuthMail(sendAuthMailRequest);
+        //then
+        verify(mailService).sendVerificationCode(email);
+    }
+
+    @DisplayName("메일 인증 번호 확인")
+    @Test
+    void verifyAuthCode() {
+        //given
+        String email = "abc@def.com";
+        String code = "123456";
+        VerifyAuthCodeRequest verifyAuthCodeRequest = new VerifyAuthCodeRequest(email, code);
+        when(mailService.verifyCode(verifyAuthCodeRequest.email(), verifyAuthCodeRequest.code())).thenReturn(true);
+        Boolean result = onboardingFacade.verifyAuthCode(verifyAuthCodeRequest);
+        verify(memberService).save(any());
+        assertEquals(result, true);
+    }
+}


### PR DESCRIPTION
### 📍 PR Type
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

### ✨ Related Issue
- #5 
---

### 📌 Task Details
- [x] 인증 이메일 전송 api 구현
- [x] 인증 이메일 검증 api 구현
- [x] 인증 이메일 관련 테스트 코드 작성
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이메일 인증 코드 발송 및 검증 API가 추가되었습니다.
    - 인증 메일 전송 시 6자리 인증 코드가 포함된 HTML 이메일이 발송됩니다.
    - 인증 코드 검증 성공 시 임시 회원이 생성됩니다.
    - 이메일 인증 요청 및 코드 검증 엔드포인트가 추가되었습니다.
    - 이메일 발송, Redis 연동, Thymeleaf 템플릿 기능이 도입되었습니다.
    - 비동기 메일 처리 및 Redis 캐시 설정이 추가되었습니다.
    - 회원 도메인 및 역할 관리 기능이 구현되었습니다.
    - 공통 엔티티에 생성/수정 시간 및 삭제 상태 관리 기능이 도입되었습니다.
    - 보안 설정에 인증 메일 관련 URL이 추가되어 비인증 접근이 허용됩니다.
    - 빌드 환경에 메일, Redis, Thymeleaf, JUnit 5 관련 라이브러리가 추가되었습니다.
    - 워크플로우에 테스트 환경 설정이 추가되어 테스트용 프로퍼티가 관리됩니다.

- **버그 수정**
    - 테스트 리소스 파일이 버전 관리에 포함되도록 `.gitignore`가 수정되었습니다.

- **문서화**
    - Swagger를 통한 API 문서화가 진행되었습니다.

- **테스트**
    - 회원 서비스 및 온보딩 기능에 대한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->