### PR TITLE
[feat] 스케쥴 추가, 수정, 삭제 API 제작

### DIFF
--- a/src/main/java/com/capstone/backend/core/common/web/response/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/capstone/backend/core/common/web/response/exception/ApiExceptionHandler.java
@@ -1,21 +1,13 @@
 package com.capstone.backend.core.common.web.response.exception;
 
-import com.capstone.backend.core.common.support.SpringContextHolder;
 import com.capstone.backend.core.common.web.response.ApiResponse;
 import com.capstone.backend.core.common.web.response.ExtendedHttpStatus;
-import com.capstone.backend.core.infrastructure.exception.CustomException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.springframework.http.HttpHeaders;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
 
 @RestControllerAdvice
 public class ApiExceptionHandler {
@@ -30,15 +22,17 @@ public class ApiExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Object> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-        BindingResult result = ex.getBindingResult();
-        StringBuilder errMessage = new StringBuilder();
-        for (FieldError error : result.getFieldErrors()) {
-            errMessage.append("[")
-                    .append(error.getField())
-                    .append("] ")
-                    .append(":")
-                    .append(error.getDefaultMessage());
-        }
-        return new ResponseEntity<>(errMessage , HttpStatus.BAD_REQUEST);
+        String message = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse("capstone.common.invalid.request");
+
+        ErrorCodeResolvingApiErrorException exception = new ErrorCodeResolvingApiErrorException(ExtendedHttpStatus.BAD_REQUEST, message);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(exception.getError()));
     }
 }

--- a/src/main/java/com/capstone/backend/core/customAnnotation/ValidDateRange.java
+++ b/src/main/java/com/capstone/backend/core/customAnnotation/ValidDateRange.java
@@ -1,0 +1,20 @@
+package com.capstone.backend.core.customAnnotation;
+
+import com.capstone.backend.core.validate.EndDateAfterDateValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = EndDateAfterDateValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidDateRange {
+    String message() default "capstone.schedule.date.not.valid";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/capstone/backend/core/validate/EndDateAfterDateValidator.java
+++ b/src/main/java/com/capstone/backend/core/validate/EndDateAfterDateValidator.java
@@ -1,0 +1,34 @@
+package com.capstone.backend.core.validate;
+
+
+import com.capstone.backend.core.customAnnotation.ValidDateRange;
+
+import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
+import com.capstone.backend.member.dto.request.CreateScheduleRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.time.LocalDate;
+
+public class EndDateAfterDateValidator implements ConstraintValidator<ValidDateRange, Object> {
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        if (value instanceof CreateScheduleRequest request) {
+            return isValidDate(request.startDate(), request.endDate(), context);
+        } else if (value instanceof ChangeScheduleRequest request) {
+            return isValidDate(request.startDate(), request.endDate(), context);
+        }
+        return true;
+    }
+
+    private boolean isValidDate(LocalDate start, LocalDate end, ConstraintValidatorContext context) {
+        if (start == null || end == null) return true;
+        if (end.isBefore(start)) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("capstone.schedule.date.not.valid")
+                    .addPropertyNode("endDate")
+                    .addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/capstone/backend/member/domain/entity/Schedule.java
+++ b/src/main/java/com/capstone/backend/member/domain/entity/Schedule.java
@@ -1,6 +1,7 @@
 package com.capstone.backend.member.domain.entity;
 
 import com.capstone.backend.member.domain.value.ScheduleType;
+import com.capstone.backend.member.dto.request.CreateScheduleRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -43,4 +44,14 @@ public class Schedule {
 
     @Column(name = "TITLE")
     private String title;
+
+    public static Schedule createSchedule(Long memberId, CreateScheduleRequest createScheduleRequest) {
+        return Schedule.builder()
+                .memberId(memberId)
+                .startDate(createScheduleRequest.startDate())
+                .endDate(createScheduleRequest.endDate())
+                .scheduleType(createScheduleRequest.scheduleType())
+                .title(createScheduleRequest.title())
+                .build();
+    }
 }

--- a/src/main/java/com/capstone/backend/member/domain/entity/Schedule.java
+++ b/src/main/java/com/capstone/backend/member/domain/entity/Schedule.java
@@ -1,6 +1,7 @@
 package com.capstone.backend.member.domain.entity;
 
 import com.capstone.backend.member.domain.value.ScheduleType;
+import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
 import com.capstone.backend.member.dto.request.CreateScheduleRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -53,5 +54,12 @@ public class Schedule {
                 .scheduleType(createScheduleRequest.scheduleType())
                 .title(createScheduleRequest.title())
                 .build();
+    }
+
+    public void changeSchedule(ChangeScheduleRequest changeScheduleRequest) {
+        this.startDate = changeScheduleRequest.startDate();
+        this.endDate = changeScheduleRequest.endDate();
+        this.scheduleType = changeScheduleRequest.scheduleType();
+        this.title = changeScheduleRequest.title();
     }
 }

--- a/src/main/java/com/capstone/backend/member/domain/entity/Schedule.java
+++ b/src/main/java/com/capstone/backend/member/domain/entity/Schedule.java
@@ -1,0 +1,46 @@
+package com.capstone.backend.member.domain.entity;
+
+import com.capstone.backend.member.domain.value.ScheduleType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "SCHEDULE")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Schedule {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "SCHEDULE_ID")
+    private Long id;
+
+    @Column(name = "MEMBER_ID")
+    private Long memberId;
+
+    @Column(name = "START_DATE")
+    private LocalDate startDate;
+
+    @Column(name = "END_DATE")
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "SCHEDULE_TYPE")
+    private ScheduleType scheduleType;
+
+    @Column(name = "TITLE")
+    private String title;
+}

--- a/src/main/java/com/capstone/backend/member/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/capstone/backend/member/domain/repository/ScheduleRepository.java
@@ -1,8 +1,9 @@
 package com.capstone.backend.member.domain.repository;
 
 import com.capstone.backend.member.domain.entity.Schedule;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
-
+    Optional<Schedule> findScheduleByMemberIdAndId(Long memberId, Long id);
 }

--- a/src/main/java/com/capstone/backend/member/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/capstone/backend/member/domain/repository/ScheduleRepository.java
@@ -1,0 +1,8 @@
+package com.capstone.backend.member.domain.repository;
+
+import com.capstone.backend.member.domain.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+}

--- a/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
@@ -1,5 +1,6 @@
 package com.capstone.backend.member.domain.service;
 
+import com.capstone.backend.core.common.web.response.ExtendedHttpStatus;
 import com.capstone.backend.core.infrastructure.exception.CustomException;
 import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.repository.ScheduleRepository;
@@ -28,7 +29,7 @@ public class ScheduleService {
     @Transactional(readOnly = true)
     public Schedule getByMemberIdAndId(Long memberId, Long scheduleId) {
         return findByMemberIdAndId(memberId, scheduleId).orElseThrow(
-                () -> new CustomException("capstone.schedule.not.found")
+                () -> new CustomException(ExtendedHttpStatus.BAD_REQUEST, "capstone.schedule.not.found")
         );
     }
 

--- a/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
@@ -4,6 +4,7 @@ import com.capstone.backend.core.infrastructure.exception.CustomException;
 import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.repository.ScheduleRepository;
 import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
+import com.capstone.backend.member.dto.request.DeleteScheduleRequest;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,5 +36,11 @@ public class ScheduleService {
     public void changeSchedule(Long memberId, ChangeScheduleRequest changeScheduleRequest) {
         Schedule schedule = getByMemberIdAndId(memberId, changeScheduleRequest.scheduleId());
         schedule.changeSchedule(changeScheduleRequest);
+    }
+
+    @Transactional
+    public void deleteSchedule(Long memberId, DeleteScheduleRequest deleteScheduleRequest) {
+        Schedule schedule = getByMemberIdAndId(memberId, deleteScheduleRequest.deleteScheduleId());
+        scheduleRepository.delete(schedule);
     }
 }

--- a/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
@@ -1,0 +1,18 @@
+package com.capstone.backend.member.domain.service;
+
+import com.capstone.backend.member.domain.entity.Schedule;
+import com.capstone.backend.member.domain.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+    private final ScheduleRepository scheduleRepository;
+
+    @Transactional
+    public void save(Schedule schedule) {
+        scheduleRepository.save(schedule);
+    }
+}

--- a/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
@@ -1,7 +1,10 @@
 package com.capstone.backend.member.domain.service;
 
+import com.capstone.backend.core.infrastructure.exception.CustomException;
 import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.repository.ScheduleRepository;
+import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,5 +17,23 @@ public class ScheduleService {
     @Transactional
     public void save(Schedule schedule) {
         scheduleRepository.save(schedule);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Schedule> findByMemberIdAndId(Long memberId, Long scheduleId) {
+        return scheduleRepository.findScheduleByMemberIdAndId(memberId, scheduleId);
+    }
+
+    @Transactional(readOnly = true)
+    public Schedule getByMemberIdAndId(Long memberId, Long scheduleId) {
+        return findByMemberIdAndId(memberId, scheduleId).orElseThrow(
+                () -> new CustomException("capstone.schedule.not.found")
+        );
+    }
+
+    @Transactional
+    public void changeSchedule(Long memberId, ChangeScheduleRequest changeScheduleRequest) {
+        Schedule schedule = getByMemberIdAndId(memberId, changeScheduleRequest.scheduleId());
+        schedule.changeSchedule(changeScheduleRequest);
     }
 }

--- a/src/main/java/com/capstone/backend/member/domain/value/ScheduleType.java
+++ b/src/main/java/com/capstone/backend/member/domain/value/ScheduleType.java
@@ -1,0 +1,5 @@
+package com.capstone.backend.member.domain.value;
+
+public enum ScheduleType {
+    EXTRACURRICULAR, NORMAL
+}

--- a/src/main/java/com/capstone/backend/member/dto/request/ChangeScheduleRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/ChangeScheduleRequest.java
@@ -1,11 +1,12 @@
 package com.capstone.backend.member.dto.request;
 
+import com.capstone.backend.core.customAnnotation.ValidDateRange;
 import com.capstone.backend.member.domain.value.ScheduleType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
-
+@ValidDateRange
 public record ChangeScheduleRequest(
         @NotNull(message = "스케쥴 id를 입력해주세요")
         @Schema(description = "수정할 스케쥴 id(pk값)", example = "1")

--- a/src/main/java/com/capstone/backend/member/dto/request/ChangeScheduleRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/ChangeScheduleRequest.java
@@ -1,0 +1,28 @@
+package com.capstone.backend.member.dto.request;
+
+import com.capstone.backend.member.domain.value.ScheduleType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record ChangeScheduleRequest(
+        @NotNull(message = "스케쥴 id를 입력해주세요")
+        @Schema(description = "수정할 스케쥴 id(pk값)", example = "1")
+        Long scheduleId,
+        @NotBlank(message = "스케쥴 제목을 입력해주세요")
+        @Schema(description = "스케줄 제목", example = "백엔드 비교과 신청")
+        String title,
+        @NotNull(message = "타입을 입력해주세요")
+        @Schema(description = "스케줄 타입", example = "EXTRACURRICULAR(비교과 관련), NORMAL(일반 일정)")
+        ScheduleType scheduleType,
+        @NotNull(message = "시작 일자를 입력해주세요")
+        @Schema(description = "시작 일자", example = "2025-07-19")
+        LocalDate startDate,
+
+        @NotNull(message = "끝 일자를 입력해주세요")
+        @Schema(description = "끝 일자", example = "2025-07-21")
+        LocalDate endDate
+) {
+
+}

--- a/src/main/java/com/capstone/backend/member/dto/request/CreateScheduleRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/CreateScheduleRequest.java
@@ -1,11 +1,13 @@
 package com.capstone.backend.member.dto.request;
 
+import com.capstone.backend.core.customAnnotation.ValidDateRange;
 import com.capstone.backend.member.domain.value.ScheduleType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
+@ValidDateRange
 public record CreateScheduleRequest(
         @NotBlank(message = "스케쥴 제목을 입력해주세요")
         @Schema(description = "스케줄 제목", example = "백엔드 비교과 신청")

--- a/src/main/java/com/capstone/backend/member/dto/request/CreateScheduleRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/CreateScheduleRequest.java
@@ -1,0 +1,26 @@
+package com.capstone.backend.member.dto.request;
+
+import com.capstone.backend.member.domain.value.ScheduleType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record CreateScheduleRequest(
+        @NotBlank(message = "스케쥴 제목을 입력해주세요")
+        @Schema(description = "스케줄 제목", example = "백엔드 비교과 신청")
+        String title,
+        @NotNull(message = "타입을 입력해주세요")
+        @Schema(description = "스케줄 타입", example = "EXTRACURRICULAR(비교과 관련), NORMAL(일반 일정)")
+        ScheduleType scheduleType,
+
+        @NotNull(message = "시작 일자를 입력해주세요")
+        @Schema(description = "시작 일자", example = "2025-07-19")
+        LocalDate startDate,
+
+        @NotNull(message = "끝 일자를 입력해주세요")
+        @Schema(description = "끝 일자", example = "2025-07-21")
+        LocalDate endDate
+) {
+
+}

--- a/src/main/java/com/capstone/backend/member/dto/request/DeleteScheduleRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/DeleteScheduleRequest.java
@@ -1,0 +1,10 @@
+package com.capstone.backend.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DeleteScheduleRequest(
+        @Schema(description = "삭제할 스케쥴 Id", example = "1")
+        Long deleteScheduleId
+) {
+
+}

--- a/src/main/java/com/capstone/backend/member/dto/request/DeleteScheduleRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/DeleteScheduleRequest.java
@@ -1,8 +1,10 @@
 package com.capstone.backend.member.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 public record DeleteScheduleRequest(
+        @NotNull(message = "삭제할 스케쥴 Id를 입력해주세요")
         @Schema(description = "삭제할 스케쥴 Id", example = "1")
         Long deleteScheduleId
 ) {

--- a/src/main/java/com/capstone/backend/member/facade/ScheduleFacade.java
+++ b/src/main/java/com/capstone/backend/member/facade/ScheduleFacade.java
@@ -4,6 +4,7 @@ import com.capstone.backend.core.auth.dto.CustomUserDetails;
 import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.service.MemberService;
 import com.capstone.backend.member.domain.service.ScheduleService;
+import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
 import com.capstone.backend.member.dto.request.CreateScheduleRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,12 @@ public class ScheduleFacade {
     public Boolean createSchedule(CustomUserDetails customUserDetails, CreateScheduleRequest createScheduleRequest) {
         Long memberId = memberService.getByEmail(customUserDetails.getUsername()).getId();
         scheduleService.save(Schedule.createSchedule(memberId, createScheduleRequest));
+        return true;
+    }
+
+    public Boolean changeSchedule(CustomUserDetails customUserDetails, ChangeScheduleRequest changeScheduleRequest) {
+        Long memberId = memberService.getByEmail(customUserDetails.getUsername()).getId();
+        scheduleService.changeSchedule(memberId, changeScheduleRequest);
         return true;
     }
 }

--- a/src/main/java/com/capstone/backend/member/facade/ScheduleFacade.java
+++ b/src/main/java/com/capstone/backend/member/facade/ScheduleFacade.java
@@ -6,6 +6,7 @@ import com.capstone.backend.member.domain.service.MemberService;
 import com.capstone.backend.member.domain.service.ScheduleService;
 import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
 import com.capstone.backend.member.dto.request.CreateScheduleRequest;
+import com.capstone.backend.member.dto.request.DeleteScheduleRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +24,12 @@ public class ScheduleFacade {
     public Boolean changeSchedule(CustomUserDetails customUserDetails, ChangeScheduleRequest changeScheduleRequest) {
         Long memberId = memberService.getByEmail(customUserDetails.getUsername()).getId();
         scheduleService.changeSchedule(memberId, changeScheduleRequest);
+        return true;
+    }
+
+    public Boolean deleteSchedule(CustomUserDetails customUserDetails, DeleteScheduleRequest deleteScheduleRequest) {
+        Long memberId = memberService.getByEmail(customUserDetails.getUsername()).getId();
+        scheduleService.deleteSchedule(memberId, deleteScheduleRequest);
         return true;
     }
 }

--- a/src/main/java/com/capstone/backend/member/facade/ScheduleFacade.java
+++ b/src/main/java/com/capstone/backend/member/facade/ScheduleFacade.java
@@ -1,0 +1,21 @@
+package com.capstone.backend.member.facade;
+
+import com.capstone.backend.core.auth.dto.CustomUserDetails;
+import com.capstone.backend.member.domain.entity.Schedule;
+import com.capstone.backend.member.domain.service.MemberService;
+import com.capstone.backend.member.domain.service.ScheduleService;
+import com.capstone.backend.member.dto.request.CreateScheduleRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduleFacade {
+    private final ScheduleService scheduleService;
+    private final MemberService memberService;
+    public Boolean createSchedule(CustomUserDetails customUserDetails, CreateScheduleRequest createScheduleRequest) {
+        Long memberId = memberService.getByEmail(customUserDetails.getUsername()).getId();
+        scheduleService.save(Schedule.createSchedule(memberId, createScheduleRequest));
+        return true;
+    }
+}

--- a/src/main/java/com/capstone/backend/member/presentation/ApiPath.java
+++ b/src/main/java/com/capstone/backend/member/presentation/ApiPath.java
@@ -16,4 +16,5 @@ public final class ApiPath {
     public static final String LOOKUP_MEMBER_INFO = "/v1/member/information";
     public static final String LOOKUP_INTEREST = "/v1/member/interest";
     public static final String ADD_SCHEDULE = "/v1/member/schedule";
+    public static final String CHANGE_SCHEDULE = "/v1/member/schedule";
 }

--- a/src/main/java/com/capstone/backend/member/presentation/ApiPath.java
+++ b/src/main/java/com/capstone/backend/member/presentation/ApiPath.java
@@ -17,4 +17,5 @@ public final class ApiPath {
     public static final String LOOKUP_INTEREST = "/v1/member/interest";
     public static final String ADD_SCHEDULE = "/v1/member/schedule";
     public static final String CHANGE_SCHEDULE = "/v1/member/schedule";
+    public static final String DELETE_SCHEDULE = "/v1/member/schedule";
 }

--- a/src/main/java/com/capstone/backend/member/presentation/ApiPath.java
+++ b/src/main/java/com/capstone/backend/member/presentation/ApiPath.java
@@ -15,4 +15,5 @@ public final class ApiPath {
     public static final String SETTING_ACADEMIC_INFO = "/v1/member/academic-info";
     public static final String LOOKUP_MEMBER_INFO = "/v1/member/information";
     public static final String LOOKUP_INTEREST = "/v1/member/interest";
+    public static final String ADD_SCHEDULE = "/v1/member/schedule";
 }

--- a/src/main/java/com/capstone/backend/member/presentation/ScheduleController.java
+++ b/src/main/java/com/capstone/backend/member/presentation/ScheduleController.java
@@ -1,0 +1,32 @@
+package com.capstone.backend.member.presentation;
+
+import com.capstone.backend.core.auth.dto.CustomUserDetails;
+import com.capstone.backend.core.common.web.response.ApiResponse;
+import com.capstone.backend.member.dto.request.CreateScheduleRequest;
+import com.capstone.backend.member.facade.ScheduleFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "스케쥴(캘린더)", description = "ScheduleController")
+public class ScheduleController {
+    private final ScheduleFacade scheduleFacade;
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping(ApiPath.ADD_SCHEDULE)
+    @Operation(summary = "스케쥴 생성", description = "createSchedule")
+    public ApiResponse<Boolean> createSchedule(
+            @RequestBody @Valid CreateScheduleRequest createScheduleRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        return ApiResponse.success(scheduleFacade.createSchedule(customUserDetails, createScheduleRequest));
+    }
+}

--- a/src/main/java/com/capstone/backend/member/presentation/ScheduleController.java
+++ b/src/main/java/com/capstone/backend/member/presentation/ScheduleController.java
@@ -4,6 +4,7 @@ import com.capstone.backend.core.auth.dto.CustomUserDetails;
 import com.capstone.backend.core.common.web.response.ApiResponse;
 import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
 import com.capstone.backend.member.dto.request.CreateScheduleRequest;
+import com.capstone.backend.member.dto.request.DeleteScheduleRequest;
 import com.capstone.backend.member.facade.ScheduleFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,5 +42,15 @@ public class ScheduleController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         return ApiResponse.success(scheduleFacade.changeSchedule(customUserDetails, changeScheduleRequest));
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping(ApiPath.DELETE_SCHEDULE)
+    @Operation(summary = "스케쥴 삭제", description = "deleteSchedule")
+    public ApiResponse<Boolean> deleteSchedule(
+            @RequestBody DeleteScheduleRequest deleteScheduleRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        return ApiResponse.success(scheduleFacade.deleteSchedule(customUserDetails, deleteScheduleRequest));
     }
 }

--- a/src/main/java/com/capstone/backend/member/presentation/ScheduleController.java
+++ b/src/main/java/com/capstone/backend/member/presentation/ScheduleController.java
@@ -2,6 +2,7 @@ package com.capstone.backend.member.presentation;
 
 import com.capstone.backend.core.auth.dto.CustomUserDetails;
 import com.capstone.backend.core.common.web.response.ApiResponse;
+import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
 import com.capstone.backend.member.dto.request.CreateScheduleRequest;
 import com.capstone.backend.member.facade.ScheduleFacade;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -28,5 +30,15 @@ public class ScheduleController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         return ApiResponse.success(scheduleFacade.createSchedule(customUserDetails, createScheduleRequest));
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PatchMapping(ApiPath.CHANGE_SCHEDULE)
+    @Operation(summary = "스케쥴 수정", description = "changeSchedule")
+    public ApiResponse<Boolean> changeSchedule(
+            @RequestBody @Valid ChangeScheduleRequest changeScheduleRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        return ApiResponse.success(scheduleFacade.changeSchedule(customUserDetails, changeScheduleRequest));
     }
 }

--- a/src/test/java/com/capstone/backend/member/domain/service/ScheduleServiceTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/service/ScheduleServiceTest.java
@@ -13,6 +13,7 @@ import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.repository.ScheduleRepository;
 import com.capstone.backend.member.domain.value.ScheduleType;
 import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
+import com.capstone.backend.member.dto.request.DeleteScheduleRequest;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -130,5 +131,19 @@ public class ScheduleServiceTest {
         assertThat(schedule.getStartDate()).isEqualTo(request.startDate());
         assertThat(schedule.getEndDate()).isEqualTo(request.endDate());
         verify(scheduleRepository).findScheduleByMemberIdAndId(memberId, schedule.getId());
+    }
+
+    @DisplayName("deleteSchedule - 성공")
+    @Test
+    void deleteSchedule_success() {
+        // given
+        DeleteScheduleRequest request = new DeleteScheduleRequest(schedule.getId());
+        when(scheduleRepository.findScheduleByMemberIdAndId(memberId, schedule.getId()))
+                .thenReturn(Optional.of(schedule));
+        // when
+        scheduleService.deleteSchedule(memberId, request);
+        //then
+        verify(scheduleRepository).findScheduleByMemberIdAndId(memberId, schedule.getId());
+        verify(scheduleRepository).delete(schedule);
     }
 }

--- a/src/test/java/com/capstone/backend/member/domain/service/ScheduleServiceTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/service/ScheduleServiceTest.java
@@ -1,0 +1,32 @@
+package com.capstone.backend.member.domain.service;
+
+import static org.mockito.Mockito.verify;
+
+import com.capstone.backend.member.domain.entity.Schedule;
+import com.capstone.backend.member.domain.repository.ScheduleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ScheduleServiceTest {
+    @Mock
+    private ScheduleRepository scheduleRepository;
+
+    @InjectMocks
+    private ScheduleService scheduleService;
+
+    @DisplayName("save - 성공")
+    @Test
+    void save_success() {
+        //given
+        Schedule schedule = Schedule.builder().build();
+        //when
+        scheduleService.save(schedule);
+        //then
+        verify(scheduleRepository).save(schedule);
+    }
+}

--- a/src/test/java/com/capstone/backend/member/domain/service/ScheduleServiceTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/service/ScheduleServiceTest.java
@@ -1,15 +1,28 @@
 package com.capstone.backend.member.domain.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.capstone.backend.core.common.support.SpringContextHolder;
+import com.capstone.backend.core.configuration.env.AppEnv;
+import com.capstone.backend.core.infrastructure.exception.CustomException;
 import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.repository.ScheduleRepository;
+import com.capstone.backend.member.domain.value.ScheduleType;
+import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
 
 @ExtendWith(MockitoExtension.class)
 public class ScheduleServiceTest {
@@ -19,14 +32,103 @@ public class ScheduleServiceTest {
     @InjectMocks
     private ScheduleService scheduleService;
 
+    @Mock
+    private AppEnv mockAppEnv;
+
+    @Mock
+    private ApplicationContext mockApplicationContext;
+
+    private Schedule schedule;
+
+    private Long memberId;
+
+    @BeforeEach
+    void setup() {
+        SpringContextHolder.setContextForTesting(mockApplicationContext);
+        lenient().when(mockApplicationContext.getBean(AppEnv.class)).thenReturn(mockAppEnv);
+        lenient().when(mockAppEnv.getId()).thenReturn("test-env");
+        schedule = Schedule.builder()
+                .title("스케쥴1")
+                .scheduleType(ScheduleType.EXTRACURRICULAR)
+                .startDate(LocalDate.of(2025, 7, 1))
+                .endDate(LocalDate.of(2025, 8, 1))
+                .build();
+        memberId = 1L;
+    }
+
     @DisplayName("save - 성공")
     @Test
     void save_success() {
-        //given
-        Schedule schedule = Schedule.builder().build();
         //when
         scheduleService.save(schedule);
         //then
         verify(scheduleRepository).save(schedule);
+    }
+
+    @DisplayName("findByMemberIdAndId - 성공")
+    @Test
+    void findByMemberIdAndId_success() {
+        // given
+        when(scheduleRepository.findScheduleByMemberIdAndId(memberId, schedule.getId()))
+                .thenReturn(Optional.of(schedule));
+        // when
+        Optional<Schedule> result = scheduleService.findByMemberIdAndId(memberId, schedule.getId());
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(schedule);
+        verify(scheduleRepository).findScheduleByMemberIdAndId(memberId, schedule.getId());
+    }
+
+    @DisplayName("getByMemberIdAndId - 성공")
+    @Test
+    void getByMemberIdAndId_success() {
+        // given
+        when(scheduleRepository.findScheduleByMemberIdAndId(memberId, schedule.getId()))
+                .thenReturn(Optional.of(schedule));
+        // when
+        Schedule result = scheduleService.getByMemberIdAndId(memberId, schedule.getId());
+        //then
+        assertThat(result).isEqualTo(schedule);
+        verify(scheduleRepository).findScheduleByMemberIdAndId(memberId, schedule.getId());
+    }
+
+    @DisplayName("getByMemberIdAndId - 해당 객체를 찾지 못할 때")
+    @Test
+    void getByMemberIdAndId_fail_not_found() {
+        // given
+        when(scheduleRepository.findScheduleByMemberIdAndId(memberId, schedule.getId()))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> scheduleService.getByMemberIdAndId(memberId, schedule.getId()))
+                .isInstanceOf(CustomException.class);
+
+        verify(scheduleRepository).findScheduleByMemberIdAndId(memberId, schedule.getId());
+    }
+
+    @DisplayName("changeSchedule - 성공")
+    @Test
+    void changeSchedule_success() {
+        // given
+        ChangeScheduleRequest request = new ChangeScheduleRequest(
+                schedule.getId(),
+                "변경된 제목",
+                ScheduleType.NORMAL,
+                LocalDate.of(2025, 9, 1),
+                LocalDate.of(2025, 10, 1)
+        );
+
+        when(scheduleRepository.findScheduleByMemberIdAndId(memberId, schedule.getId()))
+                .thenReturn(Optional.of(schedule));
+
+        // when
+        scheduleService.changeSchedule(memberId, request);
+
+        // then
+        assertThat(schedule.getTitle()).isEqualTo(request.title());
+        assertThat(schedule.getScheduleType()).isEqualTo(request.scheduleType());
+        assertThat(schedule.getStartDate()).isEqualTo(request.startDate());
+        assertThat(schedule.getEndDate()).isEqualTo(request.endDate());
+        verify(scheduleRepository).findScheduleByMemberIdAndId(memberId, schedule.getId());
     }
 }

--- a/src/test/java/com/capstone/backend/member/facade/ScheduleFacadeTest.java
+++ b/src/test/java/com/capstone/backend/member/facade/ScheduleFacadeTest.java
@@ -14,6 +14,7 @@ import com.capstone.backend.member.domain.value.Role;
 import com.capstone.backend.member.domain.value.ScheduleType;
 import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
 import com.capstone.backend.member.dto.request.CreateScheduleRequest;
+import com.capstone.backend.member.dto.request.DeleteScheduleRequest;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -84,5 +85,19 @@ public class ScheduleFacadeTest {
         assertThat(result).isTrue();
         verify(memberService).getByEmail(customUserDetails.getUsername());
         verify(scheduleService).changeSchedule(member.getId(), changeScheduleRequest);
+    }
+
+    @DisplayName("스케쥴 삭제")
+    @Test
+    void deleteSchedule() {
+        //given
+        DeleteScheduleRequest request = new DeleteScheduleRequest(1L);
+        doNothing().when(scheduleService).deleteSchedule(member.getId(), request);
+        //when
+        Boolean result = scheduleFacade.deleteSchedule(customUserDetails, request);
+        //then
+        assertThat(result).isTrue();
+        verify(memberService).getByEmail(customUserDetails.getUsername());
+        verify(scheduleService).deleteSchedule(member.getId(), request);
     }
 }

--- a/src/test/java/com/capstone/backend/member/facade/ScheduleFacadeTest.java
+++ b/src/test/java/com/capstone/backend/member/facade/ScheduleFacadeTest.java
@@ -1,5 +1,6 @@
 package com.capstone.backend.member.facade;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -7,14 +8,12 @@ import static org.mockito.Mockito.when;
 
 import com.capstone.backend.core.auth.dto.CustomUserDetails;
 import com.capstone.backend.member.domain.entity.Member;
-import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.service.MemberService;
 import com.capstone.backend.member.domain.service.ScheduleService;
 import com.capstone.backend.member.domain.value.Role;
 import com.capstone.backend.member.domain.value.ScheduleType;
+import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
 import com.capstone.backend.member.dto.request.CreateScheduleRequest;
-import com.capstone.backend.member.dto.request.SendAuthMailRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -52,7 +51,7 @@ public class ScheduleFacadeTest {
 
     @DisplayName("스케쥴 생성")
     @Test
-    void sendAuthMail() {
+    void createSchedule() {
         //given
         CreateScheduleRequest createScheduleRequest = new CreateScheduleRequest(
                 "테스트 스케쥴",
@@ -65,5 +64,25 @@ public class ScheduleFacadeTest {
         scheduleFacade.createSchedule(customUserDetails, createScheduleRequest);
         //then
         verify(scheduleService).save(any());
+    }
+
+    @DisplayName("스케쥴 수정")
+    @Test
+    void changeSchedule() {
+        //given
+        ChangeScheduleRequest changeScheduleRequest = new ChangeScheduleRequest(
+                1L,
+                "스케쥴1",
+                ScheduleType.EXTRACURRICULAR,
+                LocalDate.of(2025, 7, 1),
+                LocalDate.of(2025, 8, 1)
+        );
+        doNothing().when(scheduleService).changeSchedule(member.getId(), changeScheduleRequest);
+        //when
+        Boolean result = scheduleFacade.changeSchedule(customUserDetails, changeScheduleRequest);
+        //then
+        assertThat(result).isTrue();
+        verify(memberService).getByEmail(customUserDetails.getUsername());
+        verify(scheduleService).changeSchedule(member.getId(), changeScheduleRequest);
     }
 }

--- a/src/test/java/com/capstone/backend/member/facade/ScheduleFacadeTest.java
+++ b/src/test/java/com/capstone/backend/member/facade/ScheduleFacadeTest.java
@@ -1,0 +1,69 @@
+package com.capstone.backend.member.facade;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.capstone.backend.core.auth.dto.CustomUserDetails;
+import com.capstone.backend.member.domain.entity.Member;
+import com.capstone.backend.member.domain.entity.Schedule;
+import com.capstone.backend.member.domain.service.MemberService;
+import com.capstone.backend.member.domain.service.ScheduleService;
+import com.capstone.backend.member.domain.value.Role;
+import com.capstone.backend.member.domain.value.ScheduleType;
+import com.capstone.backend.member.dto.request.CreateScheduleRequest;
+import com.capstone.backend.member.dto.request.SendAuthMailRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ScheduleFacadeTest {
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private ScheduleService scheduleService;
+
+    @InjectMocks
+    private ScheduleFacade scheduleFacade;
+    private Member member;
+    private CustomUserDetails customUserDetails;
+    @BeforeEach
+    void setUp() {
+        String email = "test@test.com";
+        Role role = Role.ROLE_MEMBER;
+        member = Member.builder()
+                .id(1L)
+                .email(email)
+                .role(role)
+                .build();
+        customUserDetails = Mockito.mock(CustomUserDetails.class);
+        when(customUserDetails.getUsername()).thenReturn(member.getEmail());
+        when(memberService.getByEmail(member.getEmail())).thenReturn(member);
+    }
+
+    @DisplayName("스케쥴 생성")
+    @Test
+    void sendAuthMail() {
+        //given
+        CreateScheduleRequest createScheduleRequest = new CreateScheduleRequest(
+                "테스트 스케쥴",
+                ScheduleType.EXTRACURRICULAR,
+                LocalDate.of(2025,7,1),
+                LocalDate.of(2025,7,25)
+        );
+        doNothing().when(scheduleService).save(any());
+        //when
+        scheduleFacade.createSchedule(customUserDetails, createScheduleRequest);
+        //then
+        verify(scheduleService).save(any());
+    }
+}

--- a/src/test/java/com/capstone/backend/member/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/capstone/backend/member/repository/ScheduleRepositoryTest.java
@@ -1,10 +1,14 @@
 package com.capstone.backend.member.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.repository.ScheduleRepository;
+import com.capstone.backend.member.domain.value.ScheduleType;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,5 +38,25 @@ public class ScheduleRepositoryTest {
         //then
         assertEquals(memberId, schedule.getMemberId());
         assertEquals(scheduleId, schedule.getId());
+    }
+
+    @DisplayName("delete 테스트")
+    @Test
+    void delete_success() {
+        // given
+        Schedule schedule = Schedule.builder()
+                .title("삭제 테스트")
+                .scheduleType(ScheduleType.EXTRACURRICULAR)
+                .startDate(LocalDate.of(2025, 7, 1))
+                .endDate(LocalDate.of(2025, 7, 31))
+                .memberId(1L)
+                .build();
+        Schedule saved = scheduleRepository.save(schedule);
+        Long id = saved.getId();
+        // when
+        scheduleRepository.delete(saved);
+        //then
+        Optional<Schedule> result = scheduleRepository.findById(id);
+        assertThat(result).isEmpty();
     }
 }

--- a/src/test/java/com/capstone/backend/member/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/capstone/backend/member/repository/ScheduleRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.capstone.backend.member.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.capstone.backend.member.domain.entity.Schedule;
+import com.capstone.backend.member.domain.repository.ScheduleRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@Transactional
+public class ScheduleRepositoryTest {
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+
+    @DisplayName("findScheduleByMemberIdAndId 테스트")
+    @Test
+    void findScheduleByMemberIdAndId_success() {
+        //given
+        List<Schedule> scheduleList = List.of(
+                Schedule.builder().memberId(4L).title("AI 비교과").build(),
+                Schedule.builder().memberId(4L).title("웹 비교과").build(),
+                Schedule.builder().memberId(6L).title("경제 비교과").build()
+        );
+        scheduleRepository.saveAll(scheduleList);
+        Long memberId = 4L;
+        Long scheduleId = scheduleList.get(0).getId();
+        //when
+        Schedule schedule = scheduleRepository.findScheduleByMemberIdAndId(memberId, scheduleId).get();
+        //then
+        assertEquals(memberId, schedule.getMemberId());
+        assertEquals(scheduleId, schedule.getId());
+    }
+}


### PR DESCRIPTION
### 📍 PR Type
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

### ✨ Related Issue
- #29 
---

### 📌 Task Details
- [x] 스케쥴 추가 API 제작
- [x] 스케쥴 수정 API 제작
- [x] 스케쥴 삭제 API 제작
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 일정 생성, 수정, 삭제를 위한 API 엔드포인트가 추가되었습니다.
  * 일정의 제목, 유형, 시작일, 종료일을 포함하는 일정 관리 기능이 제공됩니다.
  * 일정 유형으로 "일반"과 "비교과"를 선택할 수 있습니다.
  * 일정 생성 및 수정 시 날짜 범위 유효성 검증 기능이 추가되었습니다.

* **버그 수정**
  * 해당 없음

* **테스트**
  * 일정 서비스, 파사드, 저장소에 대한 단위 테스트 및 JPA 테스트가 추가되었습니다.

* **문서화**
  * Swagger를 통한 API 문서화 및 입력값 검증이 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->