### PR TITLE
스케쥴 등록 API 변경

### DIFF
--- a/src/main/java/com/capstone/backend/core/validate/EndDateAfterDateValidator.java
+++ b/src/main/java/com/capstone/backend/core/validate/EndDateAfterDateValidator.java
@@ -13,9 +13,9 @@ public class EndDateAfterDateValidator implements ConstraintValidator<ValidDateR
     @Override
     public boolean isValid(Object value, ConstraintValidatorContext context) {
         if (value instanceof CreateScheduleRequest request) {
-            return isValidDate(request.startDate(), request.endDate(), context, "endDate");
+            return isValidDate(request.startDateTime(), request.endDateTime(), request.extracurricularId(), context, "endDate");
         } else if (value instanceof ChangeScheduleRequest request) {
-            return isValidDate(request.startDate(), request.endDate(), context, "endDate");
+            return isValidDate(request.startDateTime(), request.endDateTime(), request.extracurricularId(), context, "endDate");
         } else if (value instanceof ExtracurricularField request) {
             return isValidDate(request.applicationStart(), request.applicationEnd(), context, "applicationEnd")
                     &&
@@ -24,7 +24,14 @@ public class EndDateAfterDateValidator implements ConstraintValidator<ValidDateR
         return true;
     }
 
-    private <T extends Comparable<T>> boolean isValidDate(T start, T end, ConstraintValidatorContext context, String fieldName) {
+    private <T extends Comparable<T>> boolean isValidDate(T start, T end, Long extracurricularId, ConstraintValidatorContext context, String fieldName) {
+        if ((start == null || end == null) && extracurricularId == null) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("capstone.schedule.normal.date.blank")
+                    .addPropertyNode(fieldName)
+                    .addConstraintViolation();
+            return false;
+        }
         if (start == null || end == null) return true;
         if (end.compareTo(start) < 0) {
             context.disableDefaultConstraintViolation();
@@ -34,5 +41,9 @@ public class EndDateAfterDateValidator implements ConstraintValidator<ValidDateR
             return false;
         }
         return true;
+    }
+
+    private <T extends Comparable<T>> boolean isValidDate(T start, T end, ConstraintValidatorContext context, String fieldName) {
+        return isValidDate(start, end, null, context, fieldName);
     }
 }

--- a/src/main/java/com/capstone/backend/core/validate/EndDateAfterDateValidator.java
+++ b/src/main/java/com/capstone/backend/core/validate/EndDateAfterDateValidator.java
@@ -13,9 +13,9 @@ public class EndDateAfterDateValidator implements ConstraintValidator<ValidDateR
     @Override
     public boolean isValid(Object value, ConstraintValidatorContext context) {
         if (value instanceof CreateScheduleRequest request) {
-            return isValidDate(request.startDateTime(), request.endDateTime(), request.extracurricularId(), context, "endDate");
+            return isValidDate(request.startDateTime(), request.endDateTime(), request.extracurricularId(), context, "endDateTime");
         } else if (value instanceof ChangeScheduleRequest request) {
-            return isValidDate(request.startDateTime(), request.endDateTime(), request.extracurricularId(), context, "endDate");
+            return isValidDate(request.startDateTime(), request.endDateTime(), request.extracurricularId(), context, "endDateTime");
         } else if (value instanceof ExtracurricularField request) {
             return isValidDate(request.applicationStart(), request.applicationEnd(), context, "applicationEnd")
                     &&

--- a/src/main/java/com/capstone/backend/member/domain/entity/Extracurricular.java
+++ b/src/main/java/com/capstone/backend/member/domain/entity/Extracurricular.java
@@ -1,7 +1,6 @@
 package com.capstone.backend.member.domain.entity;
 
 import com.capstone.backend.global.entity.BaseEntity;
-import com.capstone.backend.member.dto.request.ExtracurricularField;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -24,8 +23,11 @@ import lombok.NoArgsConstructor;
 public class Extracurricular extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "EXTRACURRICULAR_ID")
+    @Column(name = "EXTRACURRICULAR_PK_ID")
     private Long id;
+
+    @Column(name = "EXTRACURRICULAR_ID")
+    private Long extracurricularId;
 
     @Column(name = "TITLE", length = 100)
     private String title;
@@ -44,24 +46,4 @@ public class Extracurricular extends BaseEntity {
 
     @Column(name = "ACTIVITY_END")
     private LocalDateTime activityEnd;
-
-    public static Extracurricular createExtraCurricular(ExtracurricularField extracurricularField) {
-        return Extracurricular.builder()
-                .title(extracurricularField.originTitle())
-                .url(extracurricularField.url())
-                .applicationStart(extracurricularField.applicationStart())
-                .applicationEnd(extracurricularField.applicationEnd())
-                .activityStart(extracurricularField.activityStart())
-                .activityEnd(extracurricularField.activityEnd())
-                .build();
-    }
-
-    public void changeExtracurricular(ExtracurricularField extracurricularField) {
-        this.title = extracurricularField.originTitle();
-        this.url = extracurricularField.url();
-        this.applicationStart = extracurricularField.applicationStart();
-        this.applicationEnd = extracurricularField.applicationEnd();
-        this.activityStart = extracurricularField.activityStart();
-        this.activityEnd = extracurricularField.activityEnd();
-    }
 }

--- a/src/main/java/com/capstone/backend/member/domain/entity/Schedule.java
+++ b/src/main/java/com/capstone/backend/member/domain/entity/Schedule.java
@@ -48,8 +48,8 @@ public class Schedule {
     public static Schedule createSchedule(Long memberId, CreateScheduleRequest createScheduleRequest) {
         return Schedule.builder()
                 .memberId(memberId)
-                .startDateTime(createScheduleRequest.startDate())
-                .endDateTime(createScheduleRequest.endDate())
+                .startDateTime(createScheduleRequest.startDateTime())
+                .endDateTime(createScheduleRequest.endDateTime())
                 .title(createScheduleRequest.title())
                 .content(createScheduleRequest.content())
                 .extracurricularId(createScheduleRequest.extracurricularId())
@@ -57,8 +57,8 @@ public class Schedule {
     }
 
     public void changeSchedule(ChangeScheduleRequest changeScheduleRequest) {
-        this.startDateTime = changeScheduleRequest.startDate();
-        this.endDateTime = changeScheduleRequest.endDate();
+        this.startDateTime = changeScheduleRequest.startDateTime();
+        this.endDateTime = changeScheduleRequest.endDateTime();
         this.title = changeScheduleRequest.title();
         this.content = changeScheduleRequest.content();
         this.extracurricularId = changeScheduleRequest.extracurricularId();

--- a/src/main/java/com/capstone/backend/member/domain/entity/Schedule.java
+++ b/src/main/java/com/capstone/backend/member/domain/entity/Schedule.java
@@ -8,7 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,11 +33,11 @@ public class Schedule {
     @Column(name = "EXTRACURRICULAR_ID")
     private Long extracurricularId;
 
-    @Column(name = "START_DATE")
-    private LocalDate startDate;
+    @Column(name = "START_DATE_TIME")
+    private LocalDateTime startDateTime;
 
-    @Column(name = "END_DATE")
-    private LocalDate endDate;
+    @Column(name = "END_DATE_TIME")
+    private LocalDateTime endDateTime;
 
     @Column(name = "TITLE")
     private String title;
@@ -48,25 +48,24 @@ public class Schedule {
     public static Schedule createSchedule(Long memberId, CreateScheduleRequest createScheduleRequest) {
         return Schedule.builder()
                 .memberId(memberId)
-                .startDate(createScheduleRequest.startDate())
-                .endDate(createScheduleRequest.endDate())
+                .startDateTime(createScheduleRequest.startDate())
+                .endDateTime(createScheduleRequest.endDate())
                 .title(createScheduleRequest.title())
                 .content(createScheduleRequest.content())
+                .extracurricularId(createScheduleRequest.extracurricularId())
                 .build();
     }
 
     public void changeSchedule(ChangeScheduleRequest changeScheduleRequest) {
-        this.startDate = changeScheduleRequest.startDate();
-        this.endDate = changeScheduleRequest.endDate();
+        this.startDateTime = changeScheduleRequest.startDate();
+        this.endDateTime = changeScheduleRequest.endDate();
         this.title = changeScheduleRequest.title();
         this.content = changeScheduleRequest.content();
+        this.extracurricularId = changeScheduleRequest.extracurricularId();
     }
 
-    public void connectExtracurricular(Long extracurricularId) {
-        this.extracurricularId = extracurricularId;
-    }
-
-    public void disconnectExtracurricular() {
-        this.extracurricularId = null;
+    public void setScheduleDateTime(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
     }
 }

--- a/src/main/java/com/capstone/backend/member/domain/repository/ExtracurricularRepository.java
+++ b/src/main/java/com/capstone/backend/member/domain/repository/ExtracurricularRepository.java
@@ -3,7 +3,10 @@ package com.capstone.backend.member.domain.repository;
 import com.capstone.backend.member.domain.entity.Extracurricular;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ExtracurricularRepository extends JpaRepository<Extracurricular, Long> {
-    Optional<Extracurricular> findByExtracurricularId(Long extracurricularId);
+    @Query("SELECT e FROM Extracurricular e WHERE e.extracurricularId = :extracurricularId")
+    Optional<Extracurricular> findByExtracurricularId(@Param("extracurricularId") Long extracurricularId);
 }

--- a/src/main/java/com/capstone/backend/member/domain/repository/ExtracurricularRepository.java
+++ b/src/main/java/com/capstone/backend/member/domain/repository/ExtracurricularRepository.java
@@ -1,8 +1,9 @@
 package com.capstone.backend.member.domain.repository;
 
 import com.capstone.backend.member.domain.entity.Extracurricular;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExtracurricularRepository extends JpaRepository<Extracurricular, Long> {
-
+    Optional<Extracurricular> findByExtracurricularId(Long extracurricularId);
 }

--- a/src/main/java/com/capstone/backend/member/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/capstone/backend/member/domain/repository/ScheduleRepository.java
@@ -15,9 +15,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             FROM Schedule s
             WHERE s.memberId = :memberId
             AND (
-                (function('YEAR', s.startDate) = :year AND function('MONTH', s.startDate) = :month)
+                (function('YEAR', s.startDateTime) = :year AND function('MONTH', s.startDateTime) = :month)
                 OR
-                (function('YEAR', s.endDate) = :year AND function('MONTH', s.endDate) = :month)
+                (function('YEAR', s.endDateTime) = :year AND function('MONTH', s.endDateTime) = :month)
             )
         """
     )

--- a/src/main/java/com/capstone/backend/member/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/capstone/backend/member/domain/repository/ScheduleRepository.java
@@ -14,12 +14,13 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             SELECT s
             FROM Schedule s
             WHERE s.memberId = :memberId
-            AND (
-                (function('YEAR', s.startDateTime) = :year AND function('MONTH', s.startDateTime) = :month)
-                OR
-                (function('YEAR', s.endDateTime) = :year AND function('MONTH', s.endDateTime) = :month)
-            )
-        """
+             AND s.startDateTime < :endExclusive
+             AND s.endDateTime >= :startInclusive
+           """
     )
-    List<Schedule> findByMemberIdAndYearAndMonth(@Param("memberId") Long memberId, @Param("year") Long year, @Param("month") Long month);
+    List<Schedule> findByMemberIdAndOverlappingRange(
+            @Param("memberId") Long memberId,
+            @Param("startInclusive") java.time.LocalDateTime startInclusive,
+            @Param("endExclusive") java.time.LocalDateTime endExclusive
+    );
 }

--- a/src/main/java/com/capstone/backend/member/domain/service/ExtracurricularService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/ExtracurricularService.java
@@ -2,8 +2,9 @@ package com.capstone.backend.member.domain.service;
 
 import com.capstone.backend.core.infrastructure.exception.CustomException;
 import com.capstone.backend.member.domain.entity.Extracurricular;
+import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.repository.ExtracurricularRepository;
-import com.capstone.backend.member.dto.request.ExtracurricularField;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,32 +19,42 @@ public class ExtracurricularService {
         return extracurricularRepository.save(extracurricular);
     }
 
-    @Transactional
-    public Extracurricular createExtracurricular(ExtracurricularField extracurricularField) {
-        Extracurricular extracurricular = Extracurricular.createExtraCurricular(extracurricularField);
-        return save(extracurricular);
-    }
-
-    @Transactional
-    public void changeExtracurricular(Long id, ExtracurricularField extracurricularField) {
-        Extracurricular extracurricular = getById(id);
-        extracurricular.changeExtracurricular(extracurricularField);
+    @Transactional(readOnly = true)
+    public Optional<Extracurricular> findByExtracurricularId(Long extracurricularId) {
+        return extracurricularRepository.findByExtracurricularId(extracurricularId);
     }
 
     @Transactional(readOnly = true)
-    public Optional<Extracurricular> findById(Long id) {
-        return extracurricularRepository.findById(id);
-    }
-
-    @Transactional(readOnly = true)
-    public Extracurricular getById(Long id) {
-        return findById(id).orElseThrow(
-                () -> new CustomException("capstone.schedule.extra.not.found")
+    public Extracurricular getByExtracurricularId(Long extracurricularId) {
+        return findByExtracurricularId(extracurricularId).orElseThrow(
+                () -> new CustomException("capstone.extra.not.found")
         );
     }
 
     @Transactional
-    public void deleteExtracurricular(Long id) {
-        extracurricularRepository.deleteById(id);
+    public void isPresent(Long extracurricularId) {
+        findByExtracurricularId(extracurricularId).orElseThrow(
+                () -> new CustomException("capstone.extra.not.found")
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public void setScheduleDate(Long extracurricularId, Schedule schedule) {
+        Extracurricular extracurricular = getByExtracurricularId(extracurricularId);
+        LocalDateTime startDateTime;
+        LocalDateTime endDateTime;
+        if(extracurricular.getActivityStart() != null && extracurricular.getActivityEnd() != null) {
+            startDateTime = extracurricular.getActivityStart();
+            endDateTime = extracurricular.getActivityEnd();
+        }
+        else if(extracurricular.getApplicationStart() != null && extracurricular.getApplicationEnd() != null) {
+            startDateTime = extracurricular.getApplicationStart();
+            endDateTime = extracurricular.getApplicationEnd();
+        }
+        else {
+            startDateTime = LocalDateTime.now();
+            endDateTime = LocalDateTime.now();
+        }
+        schedule.setScheduleDateTime(startDateTime, endDateTime);
     }
 }

--- a/src/main/java/com/capstone/backend/member/domain/service/ExtracurricularService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/ExtracurricularService.java
@@ -32,13 +32,6 @@ public class ExtracurricularService {
     }
 
     @Transactional
-    public void isPresent(Long extracurricularId) {
-        findByExtracurricularId(extracurricularId).orElseThrow(
-                () -> new CustomException("capstone.extra.not.found")
-        );
-    }
-
-    @Transactional(readOnly = true)
     public void setScheduleDate(Long extracurricularId, Schedule schedule) {
         Extracurricular extracurricular = getByExtracurricularId(extracurricularId);
         LocalDateTime startDateTime;

--- a/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
@@ -42,8 +42,10 @@ public class ScheduleService {
     @Transactional
     public void changeSchedule(Long memberId, ChangeScheduleRequest changeScheduleRequest) {
         Schedule schedule = getByMemberIdAndId(memberId, changeScheduleRequest.scheduleId());
-        extracurricularService.isPresent(changeScheduleRequest.extracurricularId());
         schedule.changeSchedule(changeScheduleRequest);
+        if((schedule.getStartDateTime() == null && schedule.getEndDateTime() == null) && changeScheduleRequest.extracurricularId() != null) {
+            extracurricularService.setScheduleDate(changeScheduleRequest.extracurricularId(), schedule);
+        }
     }
 
     @Transactional
@@ -72,7 +74,7 @@ public class ScheduleService {
     @Transactional
     public void putSchedule(Long memberId, CreateScheduleRequest createScheduleRequest) {
         Schedule schedule = Schedule.createSchedule(memberId, createScheduleRequest);
-        if((schedule.getStartDateTime() == null && schedule.getEndDateTime() == null) || createScheduleRequest.extracurricularId() != null) {
+        if((schedule.getStartDateTime() == null && schedule.getEndDateTime() == null) && createScheduleRequest.extracurricularId() != null) {
             extracurricularService.setScheduleDate(createScheduleRequest.extracurricularId(), schedule);
         }
         save(schedule);

--- a/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
@@ -8,7 +8,6 @@ import com.capstone.backend.member.domain.repository.ScheduleRepository;
 import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
 import com.capstone.backend.member.dto.request.CreateScheduleRequest;
 import com.capstone.backend.member.dto.request.DeleteScheduleRequest;
-import com.capstone.backend.member.dto.request.ExtracurricularField;
 import com.capstone.backend.member.dto.response.GetScheduleByYearAndMonthResponse;
 import com.capstone.backend.member.dto.response.GetScheduleDetailResponse;
 import java.util.List;
@@ -43,32 +42,13 @@ public class ScheduleService {
     @Transactional
     public void changeSchedule(Long memberId, ChangeScheduleRequest changeScheduleRequest) {
         Schedule schedule = getByMemberIdAndId(memberId, changeScheduleRequest.scheduleId());
+        extracurricularService.isPresent(changeScheduleRequest.extracurricularId());
         schedule.changeSchedule(changeScheduleRequest);
-        Optional<ExtracurricularField> newFieldOpt = Optional.ofNullable(changeScheduleRequest.extracurricularField());
-        Long currentExtraId = schedule.getExtracurricularId();
-        newFieldOpt.ifPresentOrElse(
-                newField -> {
-                    if (currentExtraId == null) {
-                        Long createdId = extracurricularService.createExtracurricular(newField).getId();
-                        schedule.connectExtracurricular(createdId);
-                    } else {
-                        extracurricularService.changeExtracurricular(currentExtraId, newField);
-                    }
-                },
-                () -> {
-                    if (currentExtraId != null) {
-                        extracurricularService.deleteExtracurricular(currentExtraId);
-                        schedule.disconnectExtracurricular();
-                    }
-                }
-        );
     }
 
     @Transactional
     public void deleteSchedule(Long memberId, DeleteScheduleRequest deleteScheduleRequest) {
         Schedule schedule = getByMemberIdAndId(memberId, deleteScheduleRequest.deleteScheduleId());
-        Optional.ofNullable(schedule.getExtracurricularId())
-                .ifPresent(extracurricularService::deleteExtracurricular);
         scheduleRepository.delete(schedule);
     }
 
@@ -84,7 +64,7 @@ public class ScheduleService {
     public GetScheduleDetailResponse getScheduleDetail(Long memberId, Long scheduleId) {
         Schedule schedule = getByMemberIdAndId(memberId, scheduleId);
         Extracurricular extracurricular = Optional.ofNullable(schedule.getExtracurricularId())
-                .map(extracurricularService::getById)
+                .flatMap(extracurricularService::findByExtracurricularId)
                 .orElse(null);
         return GetScheduleDetailResponse.of(schedule, extracurricular);
     }
@@ -92,10 +72,9 @@ public class ScheduleService {
     @Transactional
     public void putSchedule(Long memberId, CreateScheduleRequest createScheduleRequest) {
         Schedule schedule = Schedule.createSchedule(memberId, createScheduleRequest);
+        if((schedule.getStartDateTime() == null && schedule.getEndDateTime() == null) || createScheduleRequest.extracurricularId() != null) {
+            extracurricularService.setScheduleDate(createScheduleRequest.extracurricularId(), schedule);
+        }
         save(schedule);
-        Optional.ofNullable(createScheduleRequest.extracurricularField())
-                .map(extracurricularService::createExtracurricular)
-                .map(Extracurricular::getId)
-                .ifPresent(schedule::connectExtracurricular);
     }
 }

--- a/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
+++ b/src/main/java/com/capstone/backend/member/domain/service/ScheduleService.java
@@ -10,6 +10,8 @@ import com.capstone.backend.member.dto.request.CreateScheduleRequest;
 import com.capstone.backend.member.dto.request.DeleteScheduleRequest;
 import com.capstone.backend.member.dto.response.GetScheduleByYearAndMonthResponse;
 import com.capstone.backend.member.dto.response.GetScheduleDetailResponse;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -56,7 +58,11 @@ public class ScheduleService {
 
     @Transactional(readOnly = true)
     public List<GetScheduleByYearAndMonthResponse> findByMemberIdAndYearAndMonth(Long memberId, Long year, Long month) {
-        return scheduleRepository.findByMemberIdAndYearAndMonth(memberId, year, month)
+        YearMonth ym = YearMonth.of(year.intValue(), month.intValue());
+        LocalDateTime startInclusive = ym.atDay(1).atStartOfDay();
+        LocalDateTime endExclusive = ym.plusMonths(1).atDay(1).atStartOfDay();
+        return scheduleRepository
+                .findByMemberIdAndOverlappingRange(memberId, startInclusive, endExclusive)
                 .stream()
                 .map(GetScheduleByYearAndMonthResponse::of)
                 .toList();

--- a/src/main/java/com/capstone/backend/member/dto/request/ChangeScheduleRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/ChangeScheduleRequest.java
@@ -17,13 +17,11 @@ public record ChangeScheduleRequest(
         @NotBlank(message = "capstone.schedule.type.blank")
         @Schema(description = "스케쥴 상세정보", example = "공C487에서 열릴 예정, 시간은 17시 ~ 19시")
         String content,
-        @NotNull(message = "capstone.schedule.start.date.blank")
         @Schema(description = "시작 일자", example = "2025-07-19T14:30:45")
-        LocalDateTime startDate,
+        LocalDateTime startDateTime,
 
-        @NotNull(message = "capstone.schedule.end.date.blank")
         @Schema(description = "끝 일자", example = "2025-07-21T14:30:45")
-        LocalDateTime endDate,
+        LocalDateTime endDateTime,
 
         @Schema(description = "수정할 비교과 id")
         Long extracurricularId

--- a/src/main/java/com/capstone/backend/member/dto/request/ChangeScheduleRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/ChangeScheduleRequest.java
@@ -1,11 +1,11 @@
 package com.capstone.backend.member.dto.request;
 
 import com.capstone.backend.core.customAnnotation.ValidDateRange;
-import com.capstone.backend.member.domain.value.ScheduleType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @ValidDateRange
 public record ChangeScheduleRequest(
         @NotNull(message = "capstone.schedule.id.blank")
@@ -18,15 +18,15 @@ public record ChangeScheduleRequest(
         @Schema(description = "스케쥴 상세정보", example = "공C487에서 열릴 예정, 시간은 17시 ~ 19시")
         String content,
         @NotNull(message = "capstone.schedule.start.date.blank")
-        @Schema(description = "시작 일자", example = "2025-07-19")
-        LocalDate startDate,
+        @Schema(description = "시작 일자", example = "2025-07-19T14:30:45")
+        LocalDateTime startDate,
 
         @NotNull(message = "capstone.schedule.end.date.blank")
-        @Schema(description = "끝 일자", example = "2025-07-21")
-        LocalDate endDate,
+        @Schema(description = "끝 일자", example = "2025-07-21T14:30:45")
+        LocalDateTime endDate,
 
-        @Schema(description = "관련된 비교과(일반 일정일 경우에는 null값으로)")
-        ExtracurricularField extracurricularField
+        @Schema(description = "수정할 비교과 id")
+        Long extracurricularId
 ) {
 
 }

--- a/src/main/java/com/capstone/backend/member/dto/request/CreateScheduleRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/CreateScheduleRequest.java
@@ -16,10 +16,10 @@ public record CreateScheduleRequest(
         String content,
 
         @Schema(description = "시작 일자(비교과 관련 일정이면 null로)", example = "2025-07-19T14:30:45")
-        LocalDateTime startDate,
+        LocalDateTime startDateTime,
 
         @Schema(description = "끝 일자(비교과 관련 일정이면 null로)", example = "2025-07-21T14:30:45")
-        LocalDateTime endDate,
+        LocalDateTime endDateTime,
 
         @Schema(description = "관련된 비교과 id", example = "1")
         Long extracurricularId

--- a/src/main/java/com/capstone/backend/member/dto/request/CreateScheduleRequest.java
+++ b/src/main/java/com/capstone/backend/member/dto/request/CreateScheduleRequest.java
@@ -3,8 +3,7 @@ package com.capstone.backend.member.dto.request;
 import com.capstone.backend.core.customAnnotation.ValidDateRange;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @ValidDateRange
 public record CreateScheduleRequest(
@@ -16,16 +15,14 @@ public record CreateScheduleRequest(
         @Schema(description = "스케쥴 상세정보", example = "공C487에서 열릴 예정, 시간은 17시 ~ 19시")
         String content,
 
-        @NotNull(message = "capstone.schedule.start.date.blank")
-        @Schema(description = "시작 일자", example = "2025-07-19")
-        LocalDate startDate,
+        @Schema(description = "시작 일자(비교과 관련 일정이면 null로)", example = "2025-07-19T14:30:45")
+        LocalDateTime startDate,
 
-        @NotNull(message = "capstone.schedule.end.date.blank")
-        @Schema(description = "끝 일자", example = "2025-07-21")
-        LocalDate endDate,
+        @Schema(description = "끝 일자(비교과 관련 일정이면 null로)", example = "2025-07-21T14:30:45")
+        LocalDateTime endDate,
 
-        @Schema(description = "관련된 비교과(일반 일정일 경우에는 null값으로)", example = "")
-        ExtracurricularField extracurricularField
+        @Schema(description = "관련된 비교과 id", example = "1")
+        Long extracurricularId
 ) {
 
 }

--- a/src/main/java/com/capstone/backend/member/dto/response/GetScheduleByYearAndMonthResponse.java
+++ b/src/main/java/com/capstone/backend/member/dto/response/GetScheduleByYearAndMonthResponse.java
@@ -3,7 +3,7 @@ package com.capstone.backend.member.dto.response;
 import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.value.ScheduleType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record GetScheduleByYearAndMonthResponse(
         @Schema(description = "스케쥴 id", example = "1")
@@ -12,10 +12,10 @@ public record GetScheduleByYearAndMonthResponse(
         String title,
         @Schema(description = "스케쥴 타입", example = "EXTRACURRICULAR(비교과 관련), NORMAL(일반 일정)")
         ScheduleType scheduleType,
-        @Schema(description = "시작 날짜", example = "2025-07-19")
-        LocalDate startDate,
-        @Schema(description = "끝 날짜", example = "2025-07-20")
-        LocalDate endDate
+        @Schema(description = "시작 날짜", example = "2025-07-19T14:30:45")
+        LocalDateTime startDateTime,
+        @Schema(description = "끝 날짜", example = "2025-07-20T14:30:45")
+        LocalDateTime endDateTime
 ) {
         public static GetScheduleByYearAndMonthResponse of(
                 Schedule schedule
@@ -27,8 +27,8 @@ public record GetScheduleByYearAndMonthResponse(
                         schedule.getId(),
                         schedule.getTitle(),
                         type,
-                        schedule.getStartDate(),
-                        schedule.getEndDate()
+                        schedule.getStartDateTime(),
+                        schedule.getEndDateTime()
                 );
         }
 }

--- a/src/main/java/com/capstone/backend/member/dto/response/GetScheduleDetailResponse.java
+++ b/src/main/java/com/capstone/backend/member/dto/response/GetScheduleDetailResponse.java
@@ -5,7 +5,7 @@ import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.value.ScheduleType;
 import com.capstone.backend.member.dto.request.ExtracurricularField;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public record GetScheduleDetailResponse(
@@ -15,10 +15,10 @@ public record GetScheduleDetailResponse(
         String content,
         @Schema(description = "스케쥴 타입", example = "EXTRACURRICULAR(비교과 관련), NORMAL(일반 일정)")
         ScheduleType scheduleType,
-        @Schema(description = "시작 날짜", example = "2025-07-19")
-        LocalDate startDate,
-        @Schema(description = "끝 날짜", example = "2025-07-20")
-        LocalDate endDate,
+        @Schema(description = "시작 날짜", example = "2025-07-19T14:30:45")
+        LocalDateTime startDateTime,
+        @Schema(description = "끝 날짜", example = "2025-07-20T14:30:45")
+        LocalDateTime endDateTime,
         @Schema(description = "관련된 비교과(일반 일정일 경우에는 null값이 들어옴)")
         ExtracurricularField extracurricularField
 ) {
@@ -30,8 +30,8 @@ public record GetScheduleDetailResponse(
                 schedule.getTitle(),
                 schedule.getContent(),
                 extracurricular == null ? ScheduleType.NORMAL : ScheduleType.EXTRACURRICULAR,
-                schedule.getStartDate(),
-                schedule.getEndDate(),
+                schedule.getStartDateTime(),
+                schedule.getEndDateTime(),
                 Optional.ofNullable(extracurricular)
                         .map(e -> new ExtracurricularField(
                                 e.getTitle(),

--- a/src/test/java/com/capstone/backend/member/domain/repository/ExtracurricularRepositoryTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/repository/ExtracurricularRepositoryTest.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
 @Transactional
-public class RelatedExtracurricularRepositoryTest {
+public class ExtracurricularRepositoryTest {
     @Autowired
     private ExtracurricularRepository extracurricularRepository;
 

--- a/src/test/java/com/capstone/backend/member/domain/repository/RelatedExtracurricularRepositoryTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/repository/RelatedExtracurricularRepositoryTest.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
 @Transactional
-public class ExtracurricularRepositoryTest {
+public class RelatedExtracurricularRepositoryTest {
     @Autowired
     private ExtracurricularRepository extracurricularRepository;
 
@@ -38,7 +38,8 @@ public class ExtracurricularRepositoryTest {
         //when
         extracurricularRepository.deleteById(extracurricular.getId());
         //then
-        Optional<Extracurricular> findExtracurricular = extracurricularRepository.findById(extracurricular.getId());
+        Optional<Extracurricular> findExtracurricular = extracurricularRepository.findById(
+                extracurricular.getId());
         assertThat(findExtracurricular).isEqualTo(Optional.empty());
     }
 }

--- a/src/test/java/com/capstone/backend/member/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/repository/ScheduleRepositoryTest.java
@@ -5,9 +5,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.capstone.backend.member.domain.entity.Schedule;
-import com.capstone.backend.member.domain.repository.ScheduleRepository;
-import com.capstone.backend.member.domain.value.ScheduleType;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -47,8 +45,8 @@ public class ScheduleRepositoryTest {
         // given
         Schedule schedule = Schedule.builder()
                 .title("삭제 테스트")
-                .startDate(LocalDate.of(2025, 7, 1))
-                .endDate(LocalDate.of(2025, 7, 31))
+                .startDateTime(LocalDateTime.of(2025, 7, 1, 0, 0, 0))
+                .endDateTime(LocalDateTime.of(2025, 7, 31,0,0,0))
                 .memberId(1L)
                 .build();
         Schedule saved = scheduleRepository.save(schedule);
@@ -66,16 +64,16 @@ public class ScheduleRepositoryTest {
         //given
         Long memberId = 1L;
         Schedule scheduleStartJuly = Schedule.builder().memberId(memberId)
-                .startDate(LocalDate.of(2025, 7, 24))
-                .endDate(LocalDate.of(2025, 7, 30))
+                .startDateTime(LocalDateTime.of(2025, 7, 24, 0, 0,0))
+                .endDateTime(LocalDateTime.of(2025, 7, 30, 0, 0,0))
                 .build();
         Schedule scheduleEndJuly = Schedule.builder().memberId(memberId)
-                .startDate(LocalDate.of(2025, 6, 24))
-                .endDate(LocalDate.of(2025, 7, 30))
+                .startDateTime(LocalDateTime.of(2025, 6, 24,0,0,0))
+                .endDateTime(LocalDateTime.of(2025, 7, 30,0,0,0))
                 .build();
         Schedule scheduleStartAndEndAugust = Schedule.builder().memberId(memberId)
-                .startDate(LocalDate.of(2025, 8, 24))
-                .endDate(LocalDate.of(2025, 8, 30))
+                .startDateTime(LocalDateTime.of(2025, 8, 24,0,0,0))
+                .endDateTime(LocalDateTime.of(2025, 8, 30,0,0,0))
                 .build();
         List<Schedule> scheduleList = List.of(
                 scheduleStartJuly,
@@ -87,9 +85,9 @@ public class ScheduleRepositoryTest {
         List<Schedule> result = scheduleRepository.findByMemberIdAndYearAndMonth(1L, 2025L, 7L);
         //then
         assertThat(result).hasSize(2);
-        assertThat(result).extracting("startDate", "endDate").containsExactlyInAnyOrder(
-                tuple(scheduleStartJuly.getStartDate(), scheduleStartJuly.getEndDate()),
-                tuple(scheduleEndJuly.getStartDate(), scheduleEndJuly.getEndDate())
+        assertThat(result).extracting("startDateTime", "endDateTime").containsExactlyInAnyOrder(
+                tuple(scheduleStartJuly.getStartDateTime(), scheduleStartJuly.getEndDateTime()),
+                tuple(scheduleEndJuly.getStartDateTime(), scheduleEndJuly.getEndDateTime())
         );
     }
 }

--- a/src/test/java/com/capstone/backend/member/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/repository/ScheduleRepositoryTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.capstone.backend.member.domain.entity.Schedule;
 import java.time.LocalDateTime;
+import java.time.Year;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -58,9 +60,9 @@ public class ScheduleRepositoryTest {
         assertThat(result).isEmpty();
     }
 
-    @DisplayName("findByMemberIdAndYearAndMonth 테스트")
+    @DisplayName("findByMemberIdAndOverlappingRange 테스트")
     @Test
-    void findByMemberIdAndYearAndMonth_success() {
+    void findByMemberIdAndOverlappingRange_success() {
         //given
         Long memberId = 1L;
         Schedule scheduleStartJuly = Schedule.builder().memberId(memberId)
@@ -81,8 +83,11 @@ public class ScheduleRepositoryTest {
                 scheduleStartAndEndAugust
         );
         scheduleRepository.saveAll(scheduleList);
+        YearMonth ym = YearMonth.of(2025,7);
+        LocalDateTime startInclusive = ym.atDay(1).atStartOfDay();
+        LocalDateTime endExclusive = ym.plusMonths(1).atDay(1).atStartOfDay();
         // when
-        List<Schedule> result = scheduleRepository.findByMemberIdAndYearAndMonth(1L, 2025L, 7L);
+        List<Schedule> result = scheduleRepository.findByMemberIdAndOverlappingRange(1L, startInclusive, endExclusive);
         //then
         assertThat(result).hasSize(2);
         assertThat(result).extracting("startDateTime", "endDateTime").containsExactlyInAnyOrder(

--- a/src/test/java/com/capstone/backend/member/domain/service/ExtracurricularServiceTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/service/ExtracurricularServiceTest.java
@@ -34,7 +34,7 @@ public class ExtracurricularServiceTest {
     private ApplicationContext mockApplicationContext;
 
     @InjectMocks
-    private ExtracurricularService extraCurricularService;
+    private ExtracurricularService extracurricularService;
 
     private Extracurricular extracurricular;
     @BeforeEach
@@ -56,7 +56,7 @@ public class ExtracurricularServiceTest {
     @Test
     void save_success() {
         //when
-        extraCurricularService.save(extracurricular);
+        extracurricularService.save(extracurricular);
         //then
         verify(extracurricularRepository).save(extracurricular);
     }
@@ -68,7 +68,7 @@ public class ExtracurricularServiceTest {
         Long extraCurricularId = extracurricular.getExtracurricularId();
         when(extracurricularRepository.findByExtracurricularId(extraCurricularId)).thenReturn(Optional.of(extracurricular));
         //when
-        extraCurricularService.findByExtracurricularId(extraCurricularId);
+        extracurricularService.findByExtracurricularId(extraCurricularId);
         //then
         verify(extracurricularRepository).findByExtracurricularId(extraCurricularId);
     }
@@ -80,7 +80,7 @@ public class ExtracurricularServiceTest {
         Long extraCurricularId = extracurricular.getExtracurricularId();
         when(extracurricularRepository.findByExtracurricularId(extraCurricularId)).thenReturn(Optional.of(extracurricular));
         //when
-        extraCurricularService.getByExtracurricularId(extraCurricularId);
+        extracurricularService.getByExtracurricularId(extraCurricularId);
         //then
         verify(extracurricularRepository).findByExtracurricularId(extraCurricularId);
     }
@@ -94,7 +94,7 @@ public class ExtracurricularServiceTest {
         // when & then
         CustomException exception = assertThrows(
                 CustomException.class,
-                () -> extraCurricularService.getByExtracurricularId(extraCurricularId)
+                () -> extracurricularService.getByExtracurricularId(extraCurricularId)
         );
         ApiError error = exception.getError();
         assertThat(error.element().code().value()).isEqualTo("capstone.extra.not.found");
@@ -122,7 +122,7 @@ public class ExtracurricularServiceTest {
         Schedule schedule = Schedule.builder().build();
 
         // when
-        extraCurricularService.setScheduleDate(extraId, schedule);
+        extracurricularService.setScheduleDate(extraId, schedule);
 
         // then
         assertThat(schedule.getStartDateTime()).isEqualTo(start);
@@ -151,7 +151,7 @@ public class ExtracurricularServiceTest {
         Schedule schedule = Schedule.builder().build();
 
         // when
-        extraCurricularService.setScheduleDate(extraId, schedule);
+        extracurricularService.setScheduleDate(extraId, schedule);
 
         // then
         assertThat(schedule.getStartDateTime()).isEqualTo(start);
@@ -176,7 +176,7 @@ public class ExtracurricularServiceTest {
 
         // when
         LocalDateTime before = LocalDateTime.now();
-        extraCurricularService.setScheduleDate(extraId, schedule);
+        extracurricularService.setScheduleDate(extraId, schedule);
         LocalDateTime after  = LocalDateTime.now();
 
         // then (now는 호출 시점 차이가 있어 범위로 검증)

--- a/src/test/java/com/capstone/backend/member/domain/service/ExtracurricularServiceTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/service/ExtracurricularServiceTest.java
@@ -12,14 +12,12 @@ import com.capstone.backend.core.configuration.env.AppEnv;
 import com.capstone.backend.core.infrastructure.exception.CustomException;
 import com.capstone.backend.member.domain.entity.Extracurricular;
 import com.capstone.backend.member.domain.repository.ExtracurricularRepository;
-import com.capstone.backend.member.dto.request.ExtracurricularField;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -62,104 +60,42 @@ public class ExtracurricularServiceTest {
         verify(extracurricularRepository).save(extracurricular);
     }
 
-    @DisplayName("findById - 성공")
+    @DisplayName("findByExtracurricularId - 성공")
     @Test
     void findById_success() {
         //given
-        Long extraCurricularId = extracurricular.getId();
-        when(extracurricularRepository.findById(extraCurricularId)).thenReturn(Optional.of(extracurricular));
+        Long extraCurricularId = extracurricular.getExtracurricularId();
+        when(extracurricularRepository.findByExtracurricularId(extraCurricularId)).thenReturn(Optional.of(extracurricular));
         //when
-        extraCurricularService.findById(extraCurricularId);
+        extraCurricularService.findByExtracurricularId(extraCurricularId);
         //then
-        verify(extracurricularRepository).findById(extraCurricularId);
+        verify(extracurricularRepository).findByExtracurricularId(extraCurricularId);
     }
 
-    @DisplayName("getById - 성공")
+    @DisplayName("getByExtracurricularId - 성공")
     @Test
     void getById_success() {
         //given
-        Long extraCurricularId = extracurricular.getId();
-        when(extracurricularRepository.findById(extraCurricularId)).thenReturn(Optional.of(extracurricular));
+        Long extraCurricularId = extracurricular.getExtracurricularId();
+        when(extracurricularRepository.findByExtracurricularId(extraCurricularId)).thenReturn(Optional.of(extracurricular));
         //when
-        extraCurricularService.getById(extraCurricularId);
+        extraCurricularService.getByExtracurricularId(extraCurricularId);
         //then
-        verify(extracurricularRepository).findById(extraCurricularId);
+        verify(extracurricularRepository).findByExtracurricularId(extraCurricularId);
     }
 
-    @DisplayName("getById - 실패(못 찾았을 때)")
+    @DisplayName("getByExtracurricularId - 실패(못 찾았을 때)")
     @Test
     void findById_fail_not_found() {
         //given
-        Long extraCurricularId = extracurricular.getId();
-        when(extracurricularRepository.findById(extraCurricularId)).thenReturn(Optional.empty());
+        Long extraCurricularId = extracurricular.getExtracurricularId();
+        when(extracurricularRepository.findByExtracurricularId(extraCurricularId)).thenReturn(Optional.empty());
         // when & then
         CustomException exception = assertThrows(
                 CustomException.class,
-                () -> extraCurricularService.getById(extraCurricularId)
+                () -> extraCurricularService.getByExtracurricularId(extraCurricularId)
         );
         ApiError error = exception.getError();
-        assertThat(error.element().code().value()).isEqualTo("capstone.schedule.extra.not.found");
-    }
-
-    @DisplayName("createExtraCurricular - 성공")
-    @Test
-    void createExtraCurricular_success() {
-        //given
-        ExtracurricularField field = new ExtracurricularField(
-                "비교과A",
-                "https://abc.com",
-                LocalDateTime.of(2025, 8, 1, 9, 0),
-                LocalDateTime.of(2025, 8, 2, 9, 0),
-                LocalDateTime.of(2025, 8, 6, 9, 0),
-                LocalDateTime.of(2025, 8, 6, 12, 0)
-        );
-        //when
-        extraCurricularService.createExtracurricular(field);
-        //then
-        ArgumentCaptor<Extracurricular> extracurricularCaptor = ArgumentCaptor.forClass(Extracurricular.class);
-        verify(extracurricularRepository).save(extracurricularCaptor.capture());
-        Extracurricular savedExtracurricular = extracurricularCaptor.getValue();
-        assertThat(savedExtracurricular.getTitle()).isEqualTo(field.originTitle());
-        assertThat(savedExtracurricular.getUrl()).isEqualTo(field.url());
-        assertThat(savedExtracurricular.getApplicationStart()).isEqualTo(field.applicationStart());
-        assertThat(savedExtracurricular.getApplicationEnd()).isEqualTo(field.applicationEnd());
-        assertThat(savedExtracurricular.getActivityStart()).isEqualTo(field.activityStart());
-        assertThat(savedExtracurricular.getActivityEnd()).isEqualTo(field.activityEnd());
-    }
-
-    @DisplayName("changeExtraCurricular - 성공")
-    @Test
-    void changeExtraCurricular_success() {
-        //given
-        ExtracurricularField field = new ExtracurricularField(
-                "비교과A",
-                "https://abc.com",
-                LocalDateTime.of(2025, 8, 1, 9, 0),
-                LocalDateTime.of(2025, 8, 2, 9, 0),
-                LocalDateTime.of(2025, 8, 6, 9, 0),
-                LocalDateTime.of(2025, 8, 6, 12, 0)
-        );
-        Long extracurricularId = extracurricular.getId();
-        when(extracurricularRepository.findById(extracurricularId)).thenReturn(Optional.of(extracurricular));
-        //when
-        extraCurricularService.changeExtracurricular(extracurricularId, field);
-        //then
-        assertThat(extracurricular.getTitle()).isEqualTo(field.originTitle());
-        assertThat(extracurricular.getUrl()).isEqualTo(field.url());
-        assertThat(extracurricular.getApplicationStart()).isEqualTo(field.applicationStart());
-        assertThat(extracurricular.getApplicationEnd()).isEqualTo(field.applicationEnd());
-        assertThat(extracurricular.getActivityStart()).isEqualTo(field.activityStart());
-        assertThat(extracurricular.getActivityEnd()).isEqualTo(field.activityEnd());
-    }
-
-    @DisplayName("deleteExtraCurricular - 성공")
-    @Test
-    void deleteExtraCurricular_success() {
-        //given
-        Long extracurricularId = extracurricular.getId();
-        //when
-        extraCurricularService.deleteExtracurricular(extracurricularId);
-        //then
-        verify(extracurricularRepository).deleteById(extracurricularId);
+        assertThat(error.element().code().value()).isEqualTo("capstone.extra.not.found");
     }
 }

--- a/src/test/java/com/capstone/backend/member/domain/service/ExtracurricularServiceTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/service/ExtracurricularServiceTest.java
@@ -11,6 +11,7 @@ import com.capstone.backend.core.common.web.response.exception.ApiError;
 import com.capstone.backend.core.configuration.env.AppEnv;
 import com.capstone.backend.core.infrastructure.exception.CustomException;
 import com.capstone.backend.member.domain.entity.Extracurricular;
+import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.repository.ExtracurricularRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -97,5 +98,89 @@ public class ExtracurricularServiceTest {
         );
         ApiError error = exception.getError();
         assertThat(error.element().code().value()).isEqualTo("capstone.extra.not.found");
+    }
+
+    @Test
+    @DisplayName("setScheduleDate - 활동기간이 있으면 활동기간으로 스케줄 세팅")
+    void setScheduleDate_useActivityRange() {
+        // given
+        Long extraId = 1L;
+        LocalDateTime start = LocalDateTime.of(2025, 7, 1, 9, 0);
+        LocalDateTime end   = LocalDateTime.of(2025, 7, 2, 9, 0);
+
+        Extracurricular ext = Extracurricular.builder()
+                .extracurricularId(extraId)
+                .activityStart(start)
+                .activityEnd(end)
+                .applicationStart(LocalDateTime.of(2025, 6, 1, 9, 0))
+                .applicationEnd(LocalDateTime.of(2025, 6, 2, 9, 0))
+                .build();
+
+        when(extracurricularRepository.findByExtracurricularId(extraId))
+                .thenReturn(Optional.of(ext));
+
+        Schedule schedule = Schedule.builder().build();
+
+        // when
+        extraCurricularService.setScheduleDate(extraId, schedule);
+
+        // then
+        assertThat(schedule.getStartDateTime()).isEqualTo(start);
+        assertThat(schedule.getEndDateTime()).isEqualTo(end);
+    }
+
+    @Test
+    @DisplayName("활동기간이 null이면 신청기간으로 스케줄 세팅")
+    void setScheduleDate_useApplicationRangeWhenActivityNull() {
+        // given
+        Long extraId = 2L;
+        LocalDateTime start = LocalDateTime.of(2025, 8, 1, 9, 0);
+        LocalDateTime end   = LocalDateTime.of(2025, 8, 2, 9, 0);
+
+        Extracurricular ext = Extracurricular.builder()
+                .extracurricularId(extraId)
+                .activityStart(null)
+                .activityEnd(null)
+                .applicationStart(start)
+                .applicationEnd(end)
+                .build();
+
+        when(extracurricularRepository.findByExtracurricularId(extraId))
+                .thenReturn(Optional.of(ext));
+
+        Schedule schedule = Schedule.builder().build();
+
+        // when
+        extraCurricularService.setScheduleDate(extraId, schedule);
+
+        // then
+        assertThat(schedule.getStartDateTime()).isEqualTo(start);
+        assertThat(schedule.getEndDateTime()).isEqualTo(end);
+    }
+
+    @Test
+    @DisplayName("활동/신청기간이 모두 없으면 now로 세팅")
+    void setScheduleDate_useNowWhenNoDates() {
+        // given
+        Long extraId = 3L;
+        Extracurricular ext = Extracurricular.builder()
+                .extracurricularId(extraId)
+                .activityStart(null).activityEnd(null)
+                .applicationStart(null).applicationEnd(null)
+                .build();
+
+        when(extracurricularRepository.findByExtracurricularId(extraId))
+                .thenReturn(Optional.of(ext));
+
+        Schedule schedule = Schedule.builder().build();
+
+        // when
+        LocalDateTime before = LocalDateTime.now();
+        extraCurricularService.setScheduleDate(extraId, schedule);
+        LocalDateTime after  = LocalDateTime.now();
+
+        // then (now는 호출 시점 차이가 있어 범위로 검증)
+        assertThat(schedule.getStartDateTime()).isBetween(before.minusSeconds(1), after.plusSeconds(1));
+        assertThat(schedule.getEndDateTime()).isBetween(before.minusSeconds(1), after.plusSeconds(1));
     }
 }

--- a/src/test/java/com/capstone/backend/member/domain/service/ScheduleServiceTest.java
+++ b/src/test/java/com/capstone/backend/member/domain/service/ScheduleServiceTest.java
@@ -1,6 +1,5 @@
 package com.capstone.backend.member.domain.service;
 
-import static com.capstone.backend.member.domain.value.ScheduleType.EXTRACURRICULAR;
 import static com.capstone.backend.member.domain.value.ScheduleType.NORMAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -10,7 +9,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,7 +26,6 @@ import com.capstone.backend.member.dto.request.DeleteScheduleRequest;
 import com.capstone.backend.member.dto.request.ExtracurricularField;
 import com.capstone.backend.member.dto.response.GetScheduleByYearAndMonthResponse;
 import com.capstone.backend.member.dto.response.GetScheduleDetailResponse;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -117,8 +114,8 @@ public class ScheduleServiceTest {
         Schedule savedSchedule = scheduleCaptor.getValue();
         assertThat(savedSchedule.getTitle()).isEqualTo(createScheduleRequest.title());
         assertThat(savedSchedule.getContent()).isEqualTo(createScheduleRequest.content());
-        assertThat(savedSchedule.getStartDateTime()).isEqualTo(createScheduleRequest.startDate());
-        assertThat(savedSchedule.getEndDateTime()).isEqualTo(createScheduleRequest.endDate());
+        assertThat(savedSchedule.getStartDateTime()).isEqualTo(createScheduleRequest.startDateTime());
+        assertThat(savedSchedule.getEndDateTime()).isEqualTo(createScheduleRequest.endDateTime());
         assertThat(savedSchedule.getExtracurricularId()).isEqualTo(createScheduleRequest.extracurricularId());
     }
 
@@ -322,8 +319,8 @@ public class ScheduleServiceTest {
         verify(scheduleRepository).findScheduleByMemberIdAndId(memberId, schedule.getId());
         assertThat(schedule.getId()).isEqualTo(request.scheduleId());
         assertThat(schedule.getTitle()).isEqualTo(request.title());
-        assertThat(schedule.getStartDateTime()).isEqualTo(request.startDate());
-        assertThat(schedule.getEndDateTime()).isEqualTo(request.endDate());
+        assertThat(schedule.getStartDateTime()).isEqualTo(request.startDateTime());
+        assertThat(schedule.getEndDateTime()).isEqualTo(request.endDateTime());
         assertThat(schedule.getExtracurricularId()).isNull();
     }
 
@@ -347,8 +344,8 @@ public class ScheduleServiceTest {
         verify(scheduleRepository).findScheduleByMemberIdAndId(memberId, schedule.getId());
         assertThat(schedule.getId()).isEqualTo(request.scheduleId());
         assertThat(schedule.getTitle()).isEqualTo(request.title());
-        assertThat(schedule.getStartDateTime()).isEqualTo(request.startDate());
-        assertThat(schedule.getEndDateTime()).isEqualTo(request.endDate());
+        assertThat(schedule.getStartDateTime()).isEqualTo(request.startDateTime());
+        assertThat(schedule.getEndDateTime()).isEqualTo(request.endDateTime());
         assertThat(schedule.getExtracurricularId()).isEqualTo(request.extracurricularId());
     }
 
@@ -379,8 +376,8 @@ public class ScheduleServiceTest {
         verify(scheduleRepository).findScheduleByMemberIdAndId(memberId, extraSchedule.getId());
         assertThat(extraSchedule.getId()).isEqualTo(request.scheduleId());
         assertThat(extraSchedule.getTitle()).isEqualTo(request.title());
-        assertThat(extraSchedule.getStartDateTime()).isEqualTo(request.startDate());
-        assertThat(extraSchedule.getEndDateTime()).isEqualTo(request.endDate());
+        assertThat(extraSchedule.getStartDateTime()).isEqualTo(request.startDateTime());
+        assertThat(extraSchedule.getEndDateTime()).isEqualTo(request.endDateTime());
         assertThat(extraSchedule.getExtracurricularId()).isNull();
     }
 
@@ -411,8 +408,8 @@ public class ScheduleServiceTest {
         verify(scheduleRepository).findScheduleByMemberIdAndId(memberId, extraSchedule.getId());
         assertThat(extraSchedule.getId()).isEqualTo(request.scheduleId());
         assertThat(extraSchedule.getTitle()).isEqualTo(request.title());
-        assertThat(extraSchedule.getStartDateTime()).isEqualTo(request.startDate());
-        assertThat(extraSchedule.getEndDateTime()).isEqualTo(request.endDate());
+        assertThat(extraSchedule.getStartDateTime()).isEqualTo(request.startDateTime());
+        assertThat(extraSchedule.getEndDateTime()).isEqualTo(request.endDateTime());
         assertThat(extraSchedule.getExtracurricularId()).isEqualTo(request.extracurricularId());
     }
 
@@ -424,13 +421,13 @@ public class ScheduleServiceTest {
                 schedule.getId(),
                 "변경된 제목",
                 "변경된 세부사항",
-                LocalDateTime.of(2025, 9, 1,0,0,0),
-                LocalDateTime.of(2025, 10, 1,0,0,0),
+                null,
+                null,
                 3L
         );
         doThrow(new CustomException("capstone.extra.not.found"))
                 .when(extraCurricularService)
-                .isPresent(request.extracurricularId());
+                .setScheduleDate(eq(request.extracurricularId()), any(Schedule.class));
         //when & then
         when(scheduleRepository.findScheduleByMemberIdAndId(memberId, request.scheduleId())).thenReturn(Optional.of(schedule));
         CustomException exception = assertThrows(

--- a/src/test/java/com/capstone/backend/member/facade/ScheduleFacadeTest.java
+++ b/src/test/java/com/capstone/backend/member/facade/ScheduleFacadeTest.java
@@ -15,14 +15,12 @@ import com.capstone.backend.member.domain.entity.Schedule;
 import com.capstone.backend.member.domain.service.MemberService;
 import com.capstone.backend.member.domain.service.ScheduleService;
 import com.capstone.backend.member.domain.value.Role;
-import com.capstone.backend.member.domain.value.ScheduleType;
 import com.capstone.backend.member.dto.request.ChangeScheduleRequest;
 import com.capstone.backend.member.dto.request.CreateScheduleRequest;
 import com.capstone.backend.member.dto.request.DeleteScheduleRequest;
 import com.capstone.backend.member.dto.request.ExtracurricularField;
 import com.capstone.backend.member.dto.response.GetScheduleByYearAndMonthResponse;
 import com.capstone.backend.member.dto.response.GetScheduleDetailResponse;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,8 +64,8 @@ public class ScheduleFacadeTest {
         CreateScheduleRequest createScheduleRequest = new CreateScheduleRequest(
                 "테스트 스케쥴",
                 "테스트 상세정보",
-                LocalDate.of(2025,7,1),
-                LocalDate.of(2025,7,25),
+                LocalDateTime.of(2025,7,1,0,0,0),
+                LocalDateTime.of(2025,7,25,0,0,0),
                 null
         );
         //when
@@ -80,20 +78,12 @@ public class ScheduleFacadeTest {
     @Test
     void createSchedule_extra() {
         //given
-        ExtracurricularField extracurricularField = new ExtracurricularField(
-                "비교과A",
-                "https://abc.def",
-                LocalDateTime.of(2025,8,1,9,0),
-                LocalDateTime.of(2025,8,2,9,0),
-                LocalDateTime.of(2025,8,6,9,0),
-                LocalDateTime.of(2025,8,6,12,0)
-        );
         CreateScheduleRequest createScheduleRequest = new CreateScheduleRequest(
                 "테스트 스케쥴",
                 "테스트 상세정보",
-                LocalDate.of(2025,7,1),
-                LocalDate.of(2025,7,25),
-                extracurricularField
+                LocalDateTime.of(2025,7,1,0,0,0),
+                LocalDateTime.of(2025,7,25,0,0,0),
+                1L
         );
         //when
         scheduleFacade.createSchedule(customUserDetails, createScheduleRequest);
@@ -105,21 +95,13 @@ public class ScheduleFacadeTest {
     @Test
     void changeSchedule() {
         //given
-        ExtracurricularField extracurricularField = new ExtracurricularField(
-                "비교과A",
-                "https://abc.def",
-                LocalDateTime.of(2025,8,1,9,0),
-                LocalDateTime.of(2025,8,2,9,0),
-                LocalDateTime.of(2025,8,6,9,0),
-                LocalDateTime.of(2025,8,6,12,0)
-        );
         ChangeScheduleRequest changeScheduleRequest = new ChangeScheduleRequest(
                 1L,
                 "스케쥴1",
                 "스케쥴 상세정보",
-                LocalDate.of(2025, 7, 1),
-                LocalDate.of(2025, 8, 1),
-                extracurricularField
+                LocalDateTime.of(2025, 7, 1,0,0,0),
+                LocalDateTime.of(2025, 8, 1,0,0,0),
+                2L
         );
         //when
         Boolean result = scheduleFacade.changeSchedule(customUserDetails, changeScheduleRequest);
@@ -152,14 +134,14 @@ public class ScheduleFacadeTest {
         Schedule schedule1 = Schedule.builder()
                 .memberId(member.getId())
                 .title("비교과1")
-                .startDate(LocalDate.of(2025, 7, 1))
-                .endDate(LocalDate.of(2025, 8, 1))
+                .startDateTime(LocalDateTime.of(2025, 7, 1,0,0,0))
+                .endDateTime(LocalDateTime.of(2025, 8, 1,0,0,0))
                 .build();
         Schedule schedule2 = Schedule.builder()
                 .memberId(member.getId())
                 .title("비교과2")
-                .startDate(LocalDate.of(2025, 6, 1))
-                .endDate(LocalDate.of(2025, 7, 2))
+                .startDateTime(LocalDateTime.of(2025, 6, 1,0,0,0))
+                .endDateTime(LocalDateTime.of(2025, 7, 2,0,0,0))
                 .build();
         GetScheduleByYearAndMonthResponse response1 = GetScheduleByYearAndMonthResponse.of(schedule1);
         GetScheduleByYearAndMonthResponse response2 = GetScheduleByYearAndMonthResponse.of(schedule2);
@@ -169,9 +151,9 @@ public class ScheduleFacadeTest {
         List<GetScheduleByYearAndMonthResponse> result = scheduleFacade.getScheduleByYearAndMonth(year, month, customUserDetails);
         //then
         assertThat(result).hasSize(2);
-        assertThat(result).extracting("scheduleId","title","scheduleType","startDate","endDate").containsExactlyInAnyOrder(
-                tuple(response1.scheduleId(), response1.title(), response1.scheduleType(), response1.startDate(), response1.endDate()),
-                tuple(response2.scheduleId(), response2.title(), response2.scheduleType(), response2.startDate(), response2.endDate())
+        assertThat(result).extracting("scheduleId","title","scheduleType","startDateTime","endDateTime").containsExactlyInAnyOrder(
+                tuple(response1.scheduleId(), response1.title(), response1.scheduleType(), response1.startDateTime(), response1.endDateTime()),
+                tuple(response2.scheduleId(), response2.title(), response2.scheduleType(), response2.startDateTime(), response2.endDateTime())
         );
     }
 
@@ -180,6 +162,7 @@ public class ScheduleFacadeTest {
     void getScheduleDetail_extra() {
         //given
         Extracurricular extracurricular = Extracurricular.builder()
+                .extracurricularId(1L)
                 .title("비교과A")
                 .url("https://abc.cdf")
                 .applicationStart(LocalDateTime.of(2025,8,1,9,0))
@@ -191,9 +174,9 @@ public class ScheduleFacadeTest {
                 .memberId(member.getId())
                 .title("비교과1")
                 .content("비교과 상세정보")
-                .startDate(LocalDate.of(2025, 7, 1))
-                .endDate(LocalDate.of(2025, 8, 1))
-                .extracurricularId(extracurricular.getId())
+                .startDateTime(LocalDateTime.of(2025, 7, 1,0,0,0))
+                .endDateTime(LocalDateTime.of(2025, 8, 1,0,0,0))
+                .extracurricularId(extracurricular.getExtracurricularId())
                 .build();
         GetScheduleDetailResponse response = GetScheduleDetailResponse.of(schedule, extracurricular);
         ExtracurricularField expectedField = new ExtracurricularField(
@@ -216,8 +199,8 @@ public class ScheduleFacadeTest {
                         schedule.getTitle(),
                         schedule.getContent(),
                         EXTRACURRICULAR,
-                        schedule.getStartDate(),
-                        schedule.getEndDate(),
+                        schedule.getStartDateTime(),
+                        schedule.getEndDateTime(),
                         expectedField
                 ));
     }
@@ -230,8 +213,8 @@ public class ScheduleFacadeTest {
                 .memberId(member.getId())
                 .title("비교과1")
                 .content("비교과 상세정보")
-                .startDate(LocalDate.of(2025, 7, 1))
-                .endDate(LocalDate.of(2025, 8, 1))
+                .startDateTime(LocalDateTime.of(2025, 7, 1,0,0,0))
+                .endDateTime(LocalDateTime.of(2025, 8, 1,0,0,0))
                 .build();
         GetScheduleDetailResponse response = GetScheduleDetailResponse.of(schedule, null);
         when(scheduleService.getScheduleDetail(member.getId(), schedule.getId()))
@@ -241,13 +224,13 @@ public class ScheduleFacadeTest {
         //then
         verify(scheduleService).getScheduleDetail(member.getId(), schedule.getId());
         assertThat(result)
-                .extracting("title", "content", "scheduleType", "startDate", "endDate", "extracurricularField")
+                .extracting("title", "content", "scheduleType", "startDateTime", "endDateTime", "extracurricularField")
                 .containsExactly(
                         schedule.getTitle(),
                         schedule.getContent(),
                         NORMAL,
-                        schedule.getStartDate(),
-                        schedule.getEndDate(),
+                        schedule.getStartDateTime(),
+                        schedule.getEndDateTime(),
                         null
                 );
     }


### PR DESCRIPTION
### 📍 PR Type
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

### ✨ Related Issue
- #42 
---

### 📌 Task Details
- [x] 스케쥴 등록 API 변경
- [x] 스케쥴 수정 API 변경
- [x] DB테이블 구조 변경
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 일정이 날짜(LocalDate)에서 날짜·시간(LocalDateTime) 단위로 관리/표시됩니다.
  - 월별 조회가 시간 구간 겹침 기준으로 더 정확하게 결과를 제공합니다.
  - 비교과 연계를 객체 입력 대신 ID로 간편히 지정할 수 있습니다.
- 변경
  - 일정/상세/월별 응답의 필드가 startDateTime/endDateTime으로 변경되었습니다.
  - 일정 생성/수정 요청도 startDateTime/endDateTime 및 extracurricularId를 사용합니다.
  - 비교과 정보로부터 일정 시간대를 자동 설정하는 동작이 추가되었습니다.
  - 비교과 연계 시 일부 날짜가 비어 있어도 유효성 검사가 허용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->